### PR TITLE
Updated code for adding GIT repo directory as a config parameter.

### DIFF
--- a/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
@@ -58,7 +58,12 @@ import org.sonar.api.SonarPlugin;
     type = PropertyType.INTEGER,
     global = false,
     project = false,
-    module = false)
+    module = false),
+    @Property(
+    key = GitHubPlugin.GITHUB_BASE_DIR,
+    name = "GitHub Base Directory",
+    description = "Base Directory for git.",
+    global = false)
 })
 public class GitHubPlugin extends SonarPlugin {
 
@@ -67,6 +72,7 @@ public class GitHubPlugin extends SonarPlugin {
   public static final String GITHUB_OAUTH = "sonar.github.oauth";
   public static final String GITHUB_REPO = "sonar.github.repository";
   public static final String GITHUB_PULL_REQUEST = "sonar.github.pullRequest";
+  public static final String GITHUB_BASE_DIR = "sonar.github.basedir";
 
   @Override
   public List getExtensions() {

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -97,5 +97,9 @@ public class GitHubPluginConfiguration implements BatchComponent {
   public String endpoint() {
     return settings.getString(GitHubPlugin.GITHUB_ENDPOINT);
   }
+  
+  public String gitBaseDir() {
+	return settings.getString(GitHubPlugin.GITHUB_BASE_DIR);
+	  }
 
 }

--- a/src/main/java/org/sonar/plugins/github/PullRequestFacade.java
+++ b/src/main/java/org/sonar/plugins/github/PullRequestFacade.java
@@ -103,6 +103,9 @@ public class PullRequestFacade implements BatchComponent {
     if (baseDir == null) {
       return null;
     }
+    if(null!= config.gitBaseDir()){
+    	baseDir=new File(baseDir,config.gitBaseDir());
+    }
     if (new File(baseDir, ".git").exists()) {
       setGitBaseDir(baseDir);
       return baseDir;


### PR DESCRIPTION
We are facing issue where GIT repo directory us different from Project Base directory on Jenkins(Multi repo scenario). Hence not able to use this plugin for Automated pull request sonar build. 

With the change have added a capability to add/specify subdirectory so that GIT repo path can be specified 