### PR TITLE
Project dir doesn't need to contain .git

### DIFF
--- a/src/main/java/org/sonar/plugins/github/PullRequestFacade.java
+++ b/src/main/java/org/sonar/plugins/github/PullRequestFacade.java
@@ -73,9 +73,6 @@ public class PullRequestFacade implements BatchComponent {
   }
 
   public void init(int pullRequestNumber, File projectBaseDir) {
-    if (findGitBaseDir(projectBaseDir) == null) {
-      throw new IllegalStateException("Unable to find Git root directory. Is " + projectBaseDir + " part of a Git repository?");
-    }
     try {
       GitHub github = new GitHubBuilder().withEndpoint(config.endpoint()).withOAuthToken(config.oauth()).build();
       setGhRepo(github.getRepository(config.repository()));


### PR DESCRIPTION
In PullRequestFacade.init the first check is to make sure that the current project base directory contains a .git directory, i.e. it's a valid git repository. This can cause problems in some CI-environments where a host machine can cache checkouts, and provide build-agents just with the sources.

At a glance I don't see a reason why this check is needed. If I need to create an issue for this somewhere, please let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonarsource/sonar-github/16)
<!-- Reviewable:end -->
