### PR TITLE
feat(auth_token): Allow setting gh token globally

### DIFF
--- a/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
@@ -38,7 +38,7 @@ import org.sonar.api.SonarPlugin;
     key = GitHubPlugin.GITHUB_OAUTH,
     name = "GitHub OAuth token",
     description = "Authentication token",
-    global = false,
+    global = true,
     type = PropertyType.PASSWORD),
   @Property(
     key = GitHubPlugin.GITHUB_REPO,


### PR DESCRIPTION
Having this setting available in the global interface seems like an improvement to me.
It's still possible to set it at the project level but that way it can be set globally for companies like mine where a single bot user is used for code quality enforcement across all projects.