### PR TITLE
SONARGITUB-28 Proxy support fix

### DIFF
--- a/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
@@ -59,14 +59,6 @@ import org.sonar.api.PropertyType;
     description = "Issues will not be reported as inline comments but only in the global summary comment",
     project = true,
     global = true,
-    type = PropertyType.BOOLEAN),
-  @Property(
-    key = GitHubPlugin.GITHUB_USE_PROXY,
-    defaultValue = "false",
-    name = "Use proxy while connecting to github",
-    description = "will connect to GitHub using the proxy defined in SonarQube",
-    project = true,
-    global = true,
     type = PropertyType.BOOLEAN)
 })
 public class GitHubPlugin implements Plugin {
@@ -76,7 +68,6 @@ public class GitHubPlugin implements Plugin {
   public static final String GITHUB_REPO = "sonar.github.repository";
   public static final String GITHUB_PULL_REQUEST = "sonar.github.pullRequest";
   public static final String GITHUB_DISABLE_INLINE_COMMENTS = "sonar.github.disableInlineComments";
-  public static final String GITHUB_USE_PROXY = "sonar.github.useHttpProxy";
 
 
   @Override

--- a/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
@@ -59,6 +59,14 @@ import org.sonar.api.PropertyType;
     description = "Issues will not be reported as inline comments but only in the global summary comment",
     project = true,
     global = true,
+    type = PropertyType.BOOLEAN),
+  @Property(
+    key = GitHubPlugin.GITHUB_USE_PROXY,
+    defaultValue = "false",
+    name = "Use proxy while connecting to github",
+    description = "will connect to GitHub using the proxy defined in SonarQube",
+    project = true,
+    global = true,
     type = PropertyType.BOOLEAN)
 })
 public class GitHubPlugin implements Plugin {
@@ -68,6 +76,8 @@ public class GitHubPlugin implements Plugin {
   public static final String GITHUB_REPO = "sonar.github.repository";
   public static final String GITHUB_PULL_REQUEST = "sonar.github.pullRequest";
   public static final String GITHUB_DISABLE_INLINE_COMMENTS = "sonar.github.disableInlineComments";
+  public static final String GITHUB_USE_PROXY = "sonar.github.useHttpProxy";
+
 
   @Override
   public void define(Context context) {

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -27,6 +27,10 @@ import org.sonar.api.batch.BatchSide;
 import org.sonar.api.batch.InstantiationStrategy;
 import org.sonar.api.config.Settings;
 import org.sonar.api.utils.MessageException;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
@@ -35,6 +39,7 @@ import static org.apache.commons.lang.StringUtils.isNotBlank;
 public class GitHubPluginConfiguration {
 
   public static final int MAX_GLOBAL_ISSUES = 10;
+  private static final Logger LOG = Loggers.get(GitHubPluginConfiguration.class);
 
   private Settings settings;
   private Pattern gitSshPattern;
@@ -116,5 +121,24 @@ public class GitHubPluginConfiguration {
   public boolean tryReportIssuesInline() {
     return !settings.getBoolean(GitHubPlugin.GITHUB_DISABLE_INLINE_COMMENTS);
   }
+
+  public boolean isProxyConnectionEnabled() {
+    return settings.getBoolean(GitHubPlugin.GITHUB_USE_PROXY);
+  }
+
+
+  public Proxy getHttpProxy() {
+    try{
+      Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(System.getProperty("http.proxyHost"), Integer.valueOf(System.getProperty("http.proxyPort"))));
+      return proxy;
+    }
+    catch(NullPointerException e)
+    {
+      LOG.debug("Unable to perform GitHub WS operation - proxy is not defined in sonarQube, check http.proxyHost, http.proxyPort", e);
+      throw MessageException.of("Unable to perform GitHub WS operation - proxy is not defined in sonarQube, check http.proxyHost, http.proxyPort: " + e.getMessage());
+    }
+
+  }
+
 
 }

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -123,7 +123,12 @@ public class GitHubPluginConfiguration {
   }
 
   public boolean isProxyConnectionEnabled() {
-    return settings.getBoolean(GitHubPlugin.GITHUB_USE_PROXY);
+    boolean proxyEnabled = settings.getBoolean(GitHubPlugin.GITHUB_USE_PROXY);
+    if (proxyEnabled && System.getProperty("http.proxyHost") == null)
+    {
+      return false;
+    }
+    return proxyEnabled;
   }
 
 

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -137,10 +137,27 @@ public class GitHubPluginConfiguration {
 
 
   public Proxy getHttpProxy() {
-    try{
+    try
+    {
         if(System.getProperty("http.proxyHost") != null && System.getProperty("https.proxyHost") == null)
         {
-            System.setProperty("https.proxyHost",System.getProperty("http.proxyHost"));
+            System.setProperty("https.proxyHost", System.getProperty("http.proxyHost"));
+        }
+
+        String proxyUser;
+        String proxyPass;
+
+        if(((proxyUser = System.getProperty("http.proxyUser")) != null && (proxyPass = System.getProperty("http.proxyPassword")) != null))
+        {
+            Authenticator.setDefault(
+                    new Authenticator() {
+                        @Override
+                        public PasswordAuthentication getPasswordAuthentication() {
+                            return new PasswordAuthentication(
+                                    proxyUser, proxyPass.toCharArray());
+                        }
+                    }
+            );
         }
         Proxy selectedProxy = ProxySelector.getDefault().select(new URI(endpoint())).get(0);
         LOG.info("A proxy has been configured - " + selectedProxy.toString());

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -19,11 +19,6 @@
  */
 package org.sonar.plugins.github;
 
-import java.net.*;
-import java.util.IllegalFormatException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import javax.annotation.CheckForNull;
 import org.sonar.api.CoreProperties;
 import org.sonar.api.batch.BatchSide;
 import org.sonar.api.batch.InstantiationStrategy;
@@ -33,15 +28,31 @@ import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
+import javax.annotation.CheckForNull;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @BatchSide
 @InstantiationStrategy(InstantiationStrategy.PER_BATCH)
 public class GitHubPluginConfiguration {
 
   public static final int MAX_GLOBAL_ISSUES = 10;
-  private static final Logger LOG = Loggers.get(GitHubPluginConfiguration.class);
+    private static final Logger LOG = Loggers.get(GitHubPluginConfiguration.class);
+    public static final String HTTP_PROXY_HOSTNAME = "http.proxyHost";
+    public static final String HTTPS_PROXY_HOSTNAME = "https.proxyHost";
+    public static final String PROXY_SOCKS_HOSTNAME = "socksProxyHost";
+    public static final String HTTP_PROXY_PORT = "http.proxyPort";
+    public static final String HTTPS_PROXY_PORT = "https.proxyPort";
+    public static final String HTTP_PROXY_USER = "http.proxyUser";
+    public static final String HTTP_PROXY_PASS = "http.proxyPassword";
 
-  private Settings settings;
+    private Settings settings;
   private Pattern gitSshPattern;
   private Pattern gitHttpPattern;
 
@@ -128,8 +139,8 @@ public class GitHubPluginConfiguration {
      * @return True iff a proxy was configured to be used in the plugin.
      */
   public boolean isProxyConnectionEnabled() {
-    if (System.getProperty("http.proxyHost") != null || System.getProperty("https.proxyHost") != null ||
-            System.getProperty("socksProxyHost") != null)
+    if (System.getProperty(HTTP_PROXY_HOSTNAME) != null || System.getProperty(HTTPS_PROXY_HOSTNAME) != null ||
+            System.getProperty(PROXY_SOCKS_HOSTNAME) != null)
     {
         return true;
     }
@@ -140,15 +151,15 @@ public class GitHubPluginConfiguration {
   public Proxy getHttpProxy() {
     try
     {
-        if(System.getProperty("http.proxyHost") != null && System.getProperty("https.proxyHost") == null)
+        if(System.getProperty(HTTP_PROXY_HOSTNAME) != null && System.getProperty(HTTPS_PROXY_HOSTNAME) == null)
         {
-            System.setProperty("https.proxyHost", System.getProperty("http.proxyHost"));
-            System.setProperty("https.proxyPort", System.getProperty("http.proxyHost"));
+            System.setProperty(HTTPS_PROXY_HOSTNAME, System.getProperty(HTTP_PROXY_HOSTNAME));
+            System.setProperty(HTTPS_PROXY_PORT, System.getProperty(HTTP_PROXY_PORT));
 
         }
 
-        String proxyUser = System.getProperty("http.proxyUser");
-        String proxyPass = System.getProperty("http.proxyPassword");
+        String proxyUser = System.getProperty(HTTP_PROXY_USER);
+        String proxyPass = System.getProperty(HTTP_PROXY_PASS);
 
         if(proxyUser != null && proxyPass != null)
         {

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -43,16 +43,16 @@ import java.util.regex.Pattern;
 public class GitHubPluginConfiguration {
 
   public static final int MAX_GLOBAL_ISSUES = 10;
-    private static final Logger LOG = Loggers.get(GitHubPluginConfiguration.class);
-    public static final String HTTP_PROXY_HOSTNAME = "http.proxyHost";
-    public static final String HTTPS_PROXY_HOSTNAME = "https.proxyHost";
-    public static final String PROXY_SOCKS_HOSTNAME = "socksProxyHost";
-    public static final String HTTP_PROXY_PORT = "http.proxyPort";
-    public static final String HTTPS_PROXY_PORT = "https.proxyPort";
-    public static final String HTTP_PROXY_USER = "http.proxyUser";
-    public static final String HTTP_PROXY_PASS = "http.proxyPassword";
+  private static final Logger LOG = Loggers.get(GitHubPluginConfiguration.class);
+  public static final String HTTP_PROXY_HOSTNAME = "http.proxyHost";
+  public static final String HTTPS_PROXY_HOSTNAME = "https.proxyHost";
+  public static final String PROXY_SOCKS_HOSTNAME = "socksProxyHost";
+  public static final String HTTP_PROXY_PORT = "http.proxyPort";
+  public static final String HTTPS_PROXY_PORT = "https.proxyPort";
+  public static final String HTTP_PROXY_USER = "http.proxyUser";
+  public static final String HTTP_PROXY_PASS = "http.proxyPassword";
 
-    private Settings settings;
+  private Settings settings;
   private Pattern gitSshPattern;
   private Pattern gitHttpPattern;
 
@@ -133,60 +133,52 @@ public class GitHubPluginConfiguration {
     return !settings.getBoolean(GitHubPlugin.GITHUB_DISABLE_INLINE_COMMENTS);
   }
 
-    /**
-     * Checks if a proxy was passed with command line parameters or configured in the system.
-     * If only an HTTP proxy was configured then it's properties are copied to the HTTPS proxy (like SonarQube configuration)
-     * @return True iff a proxy was configured to be used in the plugin.
-     */
+  /**
+   * Checks if a proxy was passed with command line parameters or configured in the system.
+   * If only an HTTP proxy was configured then it's properties are copied to the HTTPS proxy (like SonarQube configuration)
+   * @return True iff a proxy was configured to be used in the plugin.
+   */
   public boolean isProxyConnectionEnabled() {
     if (System.getProperty(HTTP_PROXY_HOSTNAME) != null || System.getProperty(HTTPS_PROXY_HOSTNAME) != null ||
-            System.getProperty(PROXY_SOCKS_HOSTNAME) != null)
-    {
-        return true;
+      System.getProperty(PROXY_SOCKS_HOSTNAME) != null) {
+      return true;
     }
     return false;
   }
 
-
   public Proxy getHttpProxy() {
-    try
-    {
-        if(System.getProperty(HTTP_PROXY_HOSTNAME) != null && System.getProperty(HTTPS_PROXY_HOSTNAME) == null)
-        {
-            System.setProperty(HTTPS_PROXY_HOSTNAME, System.getProperty(HTTP_PROXY_HOSTNAME));
-            System.setProperty(HTTPS_PROXY_PORT, System.getProperty(HTTP_PROXY_PORT));
+    try {
+      if (System.getProperty(HTTP_PROXY_HOSTNAME) != null && System.getProperty(HTTPS_PROXY_HOSTNAME) == null) {
+        System.setProperty(HTTPS_PROXY_HOSTNAME, System.getProperty(HTTP_PROXY_HOSTNAME));
+        System.setProperty(HTTPS_PROXY_PORT, System.getProperty(HTTP_PROXY_PORT));
 
-        }
+      }
 
-        String proxyUser = System.getProperty(HTTP_PROXY_USER);
-        String proxyPass = System.getProperty(HTTP_PROXY_PASS);
+      String proxyUser = System.getProperty(HTTP_PROXY_USER);
+      String proxyPass = System.getProperty(HTTP_PROXY_PASS);
 
-        if(proxyUser != null && proxyPass != null)
-        {
-            Authenticator.setDefault(
-                    new Authenticator() {
-                        @Override
-                        public PasswordAuthentication getPasswordAuthentication() {
-                            return new PasswordAuthentication(
-                                    proxyUser, proxyPass.toCharArray());
-                        }
-                    }
-            );
-        }
+      if (proxyUser != null && proxyPass != null) {
+        Authenticator.setDefault(
+          new Authenticator() {
+            @Override
+            public PasswordAuthentication getPasswordAuthentication() {
+              return new PasswordAuthentication(
+                proxyUser, proxyPass.toCharArray());
+            }
+          });
+      }
 
-        Proxy selectedProxy = ProxySelector.getDefault().select(new URI(endpoint())).get(0);
+      Proxy selectedProxy = ProxySelector.getDefault().select(new URI(endpoint())).get(0);
 
-        if(selectedProxy.type() == Proxy.Type.DIRECT)
-        {
-            LOG.debug("There was no suitable proxy found to connect to GitHub - direct connection is used ");
-        }
+      if (selectedProxy.type() == Proxy.Type.DIRECT) {
+        LOG.debug("There was no suitable proxy found to connect to GitHub - direct connection is used ");
+      }
 
-        LOG.info("A proxy has been configured - " + selectedProxy.toString());
-        return selectedProxy;
-    } catch (URISyntaxException e)
-        {
-            throw new IllegalArgumentException("Unable to perform GitHub WS operation - endpoint in wrong format: " + endpoint() + e.getMessage());
-        }
+      LOG.info("A proxy has been configured - " + selectedProxy.toString());
+      return selectedProxy;
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Unable to perform GitHub WS operation - endpoint in wrong format: " + endpoint(), e);
     }
+  }
 
 }

--- a/src/main/java/org/sonar/plugins/github/PullRequestFacade.java
+++ b/src/main/java/org/sonar/plugins/github/PullRequestFacade.java
@@ -77,7 +77,15 @@ public class PullRequestFacade {
   public void init(int pullRequestNumber, File projectBaseDir) {
     initGitBaseDir(projectBaseDir);
     try {
-      GitHub github = new GitHubBuilder().withEndpoint(config.endpoint()).withOAuthToken(config.oauth()).build();
+      GitHub github;
+      if(config.isProxyConnectionEnabled())
+      {
+          github = new GitHubBuilder().withProxy(config.getHttpProxy()).withEndpoint(config.endpoint()).withOAuthToken(config.oauth()).build();
+      }
+      else
+      {
+          github = new GitHubBuilder().withEndpoint(config.endpoint()).withOAuthToken(config.oauth()).build();
+      }
       setGhRepo(github.getRepository(config.repository()));
       setPr(ghRepo.getPullRequest(pullRequestNumber));
       LOG.info("Starting analysis of pull request: " + pr.getHtmlUrl());


### PR DESCRIPTION
Hi,
I've made a small addition to solve an issue which appeared in mine Jenkins CI environment behind organization proxy while trying to automate code analysis with SonarQube with GitHub plugin and Jenkins GitHub pull request builder.
[Link to the issue on StackOverflow](http://stackoverflow.com/questions/39463511/sonarqube-jenkins-plugin-returns-server-returned-http-response-code-1-messag)

It simply tries to take the system (JVM) configured proxy or ones configured with maven flags and pass it to the GitHubBuilder as proxy. It solved my issue and I hope it will solve future issues for others.

I'd be happy if you can marge it in!