### PR TITLE
Add new setting to keep outdated PR comments

### DIFF
--- a/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
@@ -59,6 +59,14 @@ import org.sonar.api.PropertyType;
     description = "Issues will not be reported as inline comments but only in the global summary comment",
     project = true,
     global = true,
+    type = PropertyType.BOOLEAN),
+  @Property(
+    key = GitHubPlugin.GITHUB_DELETE_OUTDATED_INLINE_COMMENTS,
+    defaultValue = "true",
+    name = "Delete outdated inline comments",
+    description = "Fixed comments will be deleted. Set to false if you want to keep those.",
+    project = true,
+    global = true,
     type = PropertyType.BOOLEAN)
 })
 public class GitHubPlugin implements Plugin {
@@ -68,6 +76,7 @@ public class GitHubPlugin implements Plugin {
   public static final String GITHUB_REPO = "sonar.github.repository";
   public static final String GITHUB_PULL_REQUEST = "sonar.github.pullRequest";
   public static final String GITHUB_DISABLE_INLINE_COMMENTS = "sonar.github.disableInlineComments";
+  public static final String GITHUB_DELETE_OUTDATED_INLINE_COMMENTS = "sonar.github.deleteOutdatedInlineComments";
 
 
   @Override
@@ -79,5 +88,4 @@ public class GitHubPlugin implements Plugin {
       PullRequestFacade.class,
       MarkDownUtils.class);
   }
-
 }

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -136,6 +136,10 @@ public class GitHubPluginConfiguration {
     return !settings.getBoolean(GitHubPlugin.GITHUB_DISABLE_INLINE_COMMENTS);
   }
 
+  public boolean shouldDeleteOutdatedInlineComments() {
+    return settings.getBoolean(GitHubPlugin.GITHUB_DELETE_OUTDATED_INLINE_COMMENTS);
+  }
+
   /**
    * Checks if a proxy was passed with command line parameters or configured in the system.
    * If only an HTTP proxy was configured then it's properties are copied to the HTTPS proxy (like SonarQube configuration)

--- a/src/main/java/org/sonar/plugins/github/PullRequestIssuePostJob.java
+++ b/src/main/java/org/sonar/plugins/github/PullRequestIssuePostJob.java
@@ -60,7 +60,9 @@ public class PullRequestIssuePostJob implements PostJob {
 
     updateReviewComments(commentsToBeAddedByLine);
 
-    pullRequestFacade.deleteOutdatedComments();
+    if (gitHubPluginConfiguration.shouldDeleteOutdatedInlineComments()) {
+      pullRequestFacade.deleteOutdatedComments();
+    }
 
     pullRequestFacade.createOrUpdateGlobalComments(report.hasNewIssue() ? report.formatForMarkdown() : null);
 


### PR DESCRIPTION
Default for `sonar.github.deleteOutdatedInlineComments` is `true` to keep backwards compatibility.

We prefer to set it `false` and contribute this PR.

Thanks for this great tool :+1:

###### note: already tested in a private repo and it works as expected