### PR TITLE
Support option to turn off  Summary Comments.

### DIFF
--- a/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
@@ -59,6 +59,14 @@ import org.sonar.api.PropertyType;
     description = "Issues will not be reported as inline comments but only in the global summary comment",
     project = true,
     global = true,
+    type = PropertyType.BOOLEAN),
+   @Property(
+    key = GitHubPlugin.GITHUB_DISABLE_SUMMARY_COMMENTS,
+    defaultValue = "false",
+    name = "Disable the summary reporting",
+    description = "The summary report injected at the end of analysis will be turned off",
+    project = true,
+    global = true,
     type = PropertyType.BOOLEAN)
 })
 public class GitHubPlugin implements Plugin {
@@ -68,6 +76,7 @@ public class GitHubPlugin implements Plugin {
   public static final String GITHUB_REPO = "sonar.github.repository";
   public static final String GITHUB_PULL_REQUEST = "sonar.github.pullRequest";
   public static final String GITHUB_DISABLE_INLINE_COMMENTS = "sonar.github.disableInlineComments";
+  public static final String GITHUB_DISABLE_SUMMARY_COMMENTS = "sonar.github.disableSummaryComments";
 
 
   @Override

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -136,6 +136,10 @@ public class GitHubPluginConfiguration {
     return !settings.getBoolean(GitHubPlugin.GITHUB_DISABLE_INLINE_COMMENTS);
   }
 
+  public boolean disableSummaryComments() {
+    return settings.getBoolean(GitHubPlugin.GITHUB_DISABLE_SUMMARY_COMMENTS);
+  }
+
   /**
    * Checks if a proxy was passed with command line parameters or configured in the system.
    * If only an HTTP proxy was configured then it's properties are copied to the HTTPS proxy (like SonarQube configuration)

--- a/src/main/java/org/sonar/plugins/github/PullRequestIssuePostJob.java
+++ b/src/main/java/org/sonar/plugins/github/PullRequestIssuePostJob.java
@@ -62,7 +62,7 @@ public class PullRequestIssuePostJob implements PostJob {
 
     pullRequestFacade.deleteOutdatedComments();
 
-    pullRequestFacade.createOrUpdateGlobalComments(report.hasNewIssue() ? report.formatForMarkdown() : null);
+    pullRequestFacade.createOrUpdateGlobalComments(report.hasNewIssue() && !gitHubPluginConfiguration.disableSummaryComments() ? report.formatForMarkdown() : null);
 
     pullRequestFacade.createOrUpdateSonarQubeStatus(report.getStatus(), report.getStatusDescription());
   }

--- a/src/test/java/org/sonar/plugins/github/GitHubPluginConfigurationTest.java
+++ b/src/test/java/org/sonar/plugins/github/GitHubPluginConfigurationTest.java
@@ -114,6 +114,11 @@ public class GitHubPluginConfigurationTest {
     assertThat(config.tryReportIssuesInline()).isTrue();
     settings.setProperty(GitHubPlugin.GITHUB_DISABLE_INLINE_COMMENTS, "true");
     assertThat(config.tryReportIssuesInline()).isFalse();
+
+    assertThat(config.disableSummaryComments()).isFalse();
+    settings.setProperty(GitHubPlugin.GITHUB_DISABLE_SUMMARY_COMMENTS, "true");
+    assertThat(config.disableSummaryComments()).isTrue();
+
   }
 
   @Test


### PR DESCRIPTION
Adding an option "sonar.github.disableSummaryComments".  This is an added option to check if the summary comments needs to be updated / created or not.  By default the value is set to "false" and hence is compatible with the existing code usage.

Haven't added any test verify if the UI reflects the changes appropriately.  Will try to do that on a test instance and update here.