### PR TITLE
SONARGITUB-32: Fix images on PR comments (old SonarCommunity urls)

### DIFF
--- a/src/main/java/org/sonar/plugins/github/MarkDownUtils.java
+++ b/src/main/java/org/sonar/plugins/github/MarkDownUtils.java
@@ -35,7 +35,7 @@ import org.sonar.api.config.Settings;
 @InstantiationStrategy(InstantiationStrategy.PER_BATCH)
 public class MarkDownUtils {
 
-  private static final String IMAGES_ROOT_URL = "https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/";
+  private static final String IMAGES_ROOT_URL = "https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/";
   private final String ruleUrlPrefix;
 
   public MarkDownUtils(Settings settings) {

--- a/src/test/java/org/sonar/plugins/github/GitHubPluginConfigurationTest.java
+++ b/src/test/java/org/sonar/plugins/github/GitHubPluginConfigurationTest.java
@@ -89,7 +89,7 @@ public class GitHubPluginConfigurationTest {
     settings.removeProperty(CoreProperties.LINKS_SOURCES);
     assertThat(config.repository()).isEqualTo("SonarCommunity2/github-integration");
 
-    settings.setProperty(GitHubPlugin.GITHUB_REPO, "https://github.com/SonarCommunity/sonar-github.git");
+    settings.setProperty(GitHubPlugin.GITHUB_REPO, "https://github.com/SonarSource/sonar-github.git");
     assertThat(config.repository()).isEqualTo("SonarCommunity/sonar-github");
     settings.setProperty(GitHubPlugin.GITHUB_REPO, "http://github.com/SonarCommunity/sonar-github.git");
     assertThat(config.repository()).isEqualTo("SonarCommunity/sonar-github");

--- a/src/test/java/org/sonar/plugins/github/GitHubPluginConfigurationTest.java
+++ b/src/test/java/org/sonar/plugins/github/GitHubPluginConfigurationTest.java
@@ -77,11 +77,11 @@ public class GitHubPluginConfigurationTest {
     }
 
     settings.clear();
-    settings.setProperty(CoreProperties.LINKS_SOURCES, "scm:git:git@github.com:SonarCommunity/github-integration.git");
-    assertThat(config.repository()).isEqualTo("SonarCommunity/github-integration");
+    settings.setProperty(CoreProperties.LINKS_SOURCES, "scm:git:git@github.com:SonarSource/github-integration.git");
+    assertThat(config.repository()).isEqualTo("SonarSource/github-integration");
 
     settings.setProperty(CoreProperties.LINKS_SOURCES_DEV, "do_not_parse");
-    assertThat(config.repository()).isEqualTo("SonarCommunity/github-integration");
+    assertThat(config.repository()).isEqualTo("SonarSource/github-integration");
 
     settings.setProperty(CoreProperties.LINKS_SOURCES_DEV, "scm:git:git@github.com:SonarCommunity2/github-integration.git");
     assertThat(config.repository()).isEqualTo("SonarCommunity2/github-integration");
@@ -90,9 +90,9 @@ public class GitHubPluginConfigurationTest {
     assertThat(config.repository()).isEqualTo("SonarCommunity2/github-integration");
 
     settings.setProperty(GitHubPlugin.GITHUB_REPO, "https://github.com/SonarSource/sonar-github.git");
-    assertThat(config.repository()).isEqualTo("SonarCommunity/sonar-github");
-    settings.setProperty(GitHubPlugin.GITHUB_REPO, "http://github.com/SonarCommunity/sonar-github.git");
-    assertThat(config.repository()).isEqualTo("SonarCommunity/sonar-github");
+    assertThat(config.repository()).isEqualTo("SonarSource/sonar-github");
+    settings.setProperty(GitHubPlugin.GITHUB_REPO, "http://github.com/SonarSource/sonar-github.git");
+    assertThat(config.repository()).isEqualTo("SonarSource/sonar-github");
     settings.setProperty(GitHubPlugin.GITHUB_REPO, "SonarCommunity3/github-integration");
     assertThat(config.repository()).isEqualTo("SonarCommunity3/github-integration");
   }

--- a/src/test/java/org/sonar/plugins/github/GlobalReportTest.java
+++ b/src/test/java/org/sonar/plugins/github/GlobalReportTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.when;
 
 public class GlobalReportTest {
 
-  private static final String GITHUB_URL = "https://github.com/SonarCommunity/sonar-github";
+  private static final String GITHUB_URL = "https://github.com/SonarSource/sonar-github";
 
   private Settings settings;
 
@@ -88,7 +88,7 @@ public class GlobalReportTest {
     String desiredMarkdown = "SonarQube analysis reported 1 issue\n" +
       "* ![INFO][INFO] 1 info\n" +
       "\nWatch the comments in this conversation to review them.\n" +
-      "\n[INFO]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-info.png 'Severity: INFO'";
+      "\n[INFO]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-info.png 'Severity: INFO'";
 
     String formattedGlobalReport = globalReport.formatForMarkdown();
 
@@ -103,8 +103,8 @@ public class GlobalReportTest {
     String desiredMarkdown = "SonarQube analysis reported 1 issue\n\n" +
       "Note: The following issues were found on lines that were not modified in the pull request. Because these issues can't be reported as line comments, they are summarized here:\n\n"
       +
-      "1. ![INFO][INFO] component0: Issue0 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule0)\n" +
-      "\n[INFO]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-info.png 'Severity: INFO'";
+      "1. ![INFO][INFO] component0: Issue0 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule0)\n" +
+      "\n[INFO]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-info.png 'Severity: INFO'";
 
     String formattedGlobalReport = globalReport.formatForMarkdown();
 
@@ -128,11 +128,11 @@ public class GlobalReportTest {
       "* ![INFO][INFO] 1 info\n" +
       "\nWatch the comments in this conversation to review them.\n"
       + "\n"
-      + "[BLOCKER]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'\n"
-      + "[CRITICAL]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-critical.png 'Severity: CRITICAL'\n"
-      + "[INFO]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-info.png 'Severity: INFO'\n"
-      + "[MAJOR]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-major.png 'Severity: MAJOR'\n"
-      + "[MINOR]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-minor.png 'Severity: MINOR'";
+      + "[BLOCKER]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'\n"
+      + "[CRITICAL]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-critical.png 'Severity: CRITICAL'\n"
+      + "[INFO]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-info.png 'Severity: INFO'\n"
+      + "[MAJOR]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-major.png 'Severity: MAJOR'\n"
+      + "[MINOR]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-minor.png 'Severity: MINOR'";
 
     String formattedGlobalReport = globalReport.formatForMarkdown();
 
@@ -158,15 +158,15 @@ public class GlobalReportTest {
       "\n#### 2 extra issues\n" +
       "\nNote: The following issues were found on lines that were not modified in the pull request. Because these issues can't be reported as line comments, they are summarized here:\n\n"
       +
-      "1. ![MINOR][MINOR] [sonar-github](https://github.com/SonarCommunity/sonar-github): Issue 1 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule1)\n"
+      "1. ![MINOR][MINOR] [sonar-github](https://github.com/SonarSource/sonar-github): Issue 1 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule1)\n"
       +
-      "1. ![CRITICAL][CRITICAL] [sonar-github](https://github.com/SonarCommunity/sonar-github): Issue 3 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule3)\n"
+      "1. ![CRITICAL][CRITICAL] [sonar-github](https://github.com/SonarSource/sonar-github): Issue 3 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule3)\n"
       + "\n"
-      + "[BLOCKER]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'\n"
-      + "[CRITICAL]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-critical.png 'Severity: CRITICAL'\n"
-      + "[INFO]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-info.png 'Severity: INFO'\n"
-      + "[MAJOR]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-major.png 'Severity: MAJOR'\n"
-      + "[MINOR]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-minor.png 'Severity: MINOR'";
+      + "[BLOCKER]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'\n"
+      + "[CRITICAL]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-critical.png 'Severity: CRITICAL'\n"
+      + "[INFO]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-info.png 'Severity: INFO'\n"
+      + "[MAJOR]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-major.png 'Severity: MAJOR'\n"
+      + "[MINOR]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-minor.png 'Severity: MINOR'";
 
     String formattedGlobalReport = globalReport.formatForMarkdown();
 
@@ -183,21 +183,21 @@ public class GlobalReportTest {
     globalReport.process(newMockedIssue("component", null, null, Severity.BLOCKER, true, "Issue 4", "rule4"), GITHUB_URL, false);
 
     String desiredMarkdown = "SonarQube analysis reported 5 issues\n\n" +
-      "1. ![INFO][INFO] [sonar-github](https://github.com/SonarCommunity/sonar-github): Issue 0 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule0)\n"
+      "1. ![INFO][INFO] [sonar-github](https://github.com/SonarSource/sonar-github): Issue 0 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule0)\n"
       +
-      "1. ![MINOR][MINOR] [sonar-github](https://github.com/SonarCommunity/sonar-github): Issue 1 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule1)\n"
+      "1. ![MINOR][MINOR] [sonar-github](https://github.com/SonarSource/sonar-github): Issue 1 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule1)\n"
       +
-      "1. ![MAJOR][MAJOR] [sonar-github](https://github.com/SonarCommunity/sonar-github): Issue 2 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule2)\n"
+      "1. ![MAJOR][MAJOR] [sonar-github](https://github.com/SonarSource/sonar-github): Issue 2 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule2)\n"
       +
-      "1. ![CRITICAL][CRITICAL] [sonar-github](https://github.com/SonarCommunity/sonar-github): Issue 3 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule3)\n"
+      "1. ![CRITICAL][CRITICAL] [sonar-github](https://github.com/SonarSource/sonar-github): Issue 3 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule3)\n"
       +
-      "1. ![BLOCKER][BLOCKER] [sonar-github](https://github.com/SonarCommunity/sonar-github): Issue 4 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule4)\n"
+      "1. ![BLOCKER][BLOCKER] [sonar-github](https://github.com/SonarSource/sonar-github): Issue 4 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule4)\n"
       + "\n"
-      + "[BLOCKER]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'\n"
-      + "[CRITICAL]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-critical.png 'Severity: CRITICAL'\n"
-      + "[INFO]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-info.png 'Severity: INFO'\n"
-      + "[MAJOR]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-major.png 'Severity: MAJOR'\n"
-      + "[MINOR]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-minor.png 'Severity: MINOR'";
+      + "[BLOCKER]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'\n"
+      + "[CRITICAL]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-critical.png 'Severity: CRITICAL'\n"
+      + "[INFO]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-info.png 'Severity: INFO'\n"
+      + "[MAJOR]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-major.png 'Severity: MAJOR'\n"
+      + "[MINOR]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-minor.png 'Severity: MINOR'";
 
     String formattedGlobalReport = globalReport.formatForMarkdown();
 
@@ -220,19 +220,19 @@ public class GlobalReportTest {
       "* ![MINOR][MINOR] 1 minor\n" +
       "* ![INFO][INFO] 1 info\n" +
       "\n#### Top 4 issues\n\n" +
-      "1. ![INFO][INFO] [sonar-github](https://github.com/SonarCommunity/sonar-github): Issue 0 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule0)\n"
+      "1. ![INFO][INFO] [sonar-github](https://github.com/SonarSource/sonar-github): Issue 0 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule0)\n"
       +
-      "1. ![MINOR][MINOR] [sonar-github](https://github.com/SonarCommunity/sonar-github): Issue 1 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule1)\n"
+      "1. ![MINOR][MINOR] [sonar-github](https://github.com/SonarSource/sonar-github): Issue 1 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule1)\n"
       +
-      "1. ![MAJOR][MAJOR] [sonar-github](https://github.com/SonarCommunity/sonar-github): Issue 2 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule2)\n"
+      "1. ![MAJOR][MAJOR] [sonar-github](https://github.com/SonarSource/sonar-github): Issue 2 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule2)\n"
       +
-      "1. ![CRITICAL][CRITICAL] [sonar-github](https://github.com/SonarCommunity/sonar-github): Issue 3 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule3)\n"
+      "1. ![CRITICAL][CRITICAL] [sonar-github](https://github.com/SonarSource/sonar-github): Issue 3 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule3)\n"
       + "\n"
-      + "[BLOCKER]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'\n"
-      + "[CRITICAL]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-critical.png 'Severity: CRITICAL'\n"
-      + "[INFO]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-info.png 'Severity: INFO'\n"
-      + "[MAJOR]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-major.png 'Severity: MAJOR'\n"
-      + "[MINOR]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-minor.png 'Severity: MINOR'";
+      + "[BLOCKER]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'\n"
+      + "[CRITICAL]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-critical.png 'Severity: CRITICAL'\n"
+      + "[INFO]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-info.png 'Severity: INFO'\n"
+      + "[MAJOR]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-major.png 'Severity: MAJOR'\n"
+      + "[MINOR]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-minor.png 'Severity: MINOR'";
 
     String formattedGlobalReport = globalReport.formatForMarkdown();
 
@@ -251,27 +251,27 @@ public class GlobalReportTest {
       "\n#### Top 10 extra issues\n" +
       "\nNote: The following issues were found on lines that were not modified in the pull request. Because these issues can't be reported as line comments, they are summarized here:\n\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L0](https://github.com/SonarCommunity/sonar-github/File.java#L0): Issue number:0 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule0)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L0](https://github.com/SonarSource/sonar-github/File.java#L0): Issue number:0 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule0)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L1](https://github.com/SonarCommunity/sonar-github/File.java#L1): Issue number:1 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule1)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L1](https://github.com/SonarSource/sonar-github/File.java#L1): Issue number:1 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule1)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L2](https://github.com/SonarCommunity/sonar-github/File.java#L2): Issue number:2 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule2)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L2](https://github.com/SonarSource/sonar-github/File.java#L2): Issue number:2 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule2)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L3](https://github.com/SonarCommunity/sonar-github/File.java#L3): Issue number:3 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule3)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L3](https://github.com/SonarSource/sonar-github/File.java#L3): Issue number:3 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule3)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L4](https://github.com/SonarCommunity/sonar-github/File.java#L4): Issue number:4 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule4)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L4](https://github.com/SonarSource/sonar-github/File.java#L4): Issue number:4 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule4)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L5](https://github.com/SonarCommunity/sonar-github/File.java#L5): Issue number:5 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule5)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L5](https://github.com/SonarSource/sonar-github/File.java#L5): Issue number:5 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule5)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L6](https://github.com/SonarCommunity/sonar-github/File.java#L6): Issue number:6 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule6)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L6](https://github.com/SonarSource/sonar-github/File.java#L6): Issue number:6 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule6)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L7](https://github.com/SonarCommunity/sonar-github/File.java#L7): Issue number:7 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule7)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L7](https://github.com/SonarSource/sonar-github/File.java#L7): Issue number:7 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule7)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L8](https://github.com/SonarCommunity/sonar-github/File.java#L8): Issue number:8 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule8)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L8](https://github.com/SonarSource/sonar-github/File.java#L8): Issue number:8 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule8)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L9](https://github.com/SonarCommunity/sonar-github/File.java#L9): Issue number:9 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule9)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L9](https://github.com/SonarSource/sonar-github/File.java#L9): Issue number:9 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule9)\n"
       + "\n"
-      + "[MAJOR]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-major.png 'Severity: MAJOR'";
+      + "[MAJOR]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-major.png 'Severity: MAJOR'";
 
     String formattedGlobalReport = globalReport.formatForMarkdown();
 
@@ -288,27 +288,27 @@ public class GlobalReportTest {
     String desiredMarkdown = "SonarQube analysis reported 17 issues\n" +
       "* ![MAJOR][MAJOR] 17 major\n" +
       "\n#### Top 10 issues\n\n" +
-      "1. ![MAJOR][MAJOR] [File.java#L0](https://github.com/SonarCommunity/sonar-github/File.java#L0): Issue number:0 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule0)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L0](https://github.com/SonarSource/sonar-github/File.java#L0): Issue number:0 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule0)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L1](https://github.com/SonarCommunity/sonar-github/File.java#L1): Issue number:1 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule1)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L1](https://github.com/SonarSource/sonar-github/File.java#L1): Issue number:1 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule1)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L2](https://github.com/SonarCommunity/sonar-github/File.java#L2): Issue number:2 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule2)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L2](https://github.com/SonarSource/sonar-github/File.java#L2): Issue number:2 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule2)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L3](https://github.com/SonarCommunity/sonar-github/File.java#L3): Issue number:3 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule3)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L3](https://github.com/SonarSource/sonar-github/File.java#L3): Issue number:3 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule3)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L4](https://github.com/SonarCommunity/sonar-github/File.java#L4): Issue number:4 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule4)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L4](https://github.com/SonarSource/sonar-github/File.java#L4): Issue number:4 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule4)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L5](https://github.com/SonarCommunity/sonar-github/File.java#L5): Issue number:5 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule5)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L5](https://github.com/SonarSource/sonar-github/File.java#L5): Issue number:5 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule5)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L6](https://github.com/SonarCommunity/sonar-github/File.java#L6): Issue number:6 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule6)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L6](https://github.com/SonarSource/sonar-github/File.java#L6): Issue number:6 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule6)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L7](https://github.com/SonarCommunity/sonar-github/File.java#L7): Issue number:7 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule7)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L7](https://github.com/SonarSource/sonar-github/File.java#L7): Issue number:7 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule7)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L8](https://github.com/SonarCommunity/sonar-github/File.java#L8): Issue number:8 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule8)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L8](https://github.com/SonarSource/sonar-github/File.java#L8): Issue number:8 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule8)\n"
       +
-      "1. ![MAJOR][MAJOR] [File.java#L9](https://github.com/SonarCommunity/sonar-github/File.java#L9): Issue number:9 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule9)\n"
+      "1. ![MAJOR][MAJOR] [File.java#L9](https://github.com/SonarSource/sonar-github/File.java#L9): Issue number:9 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule9)\n"
       + "\n"
-      + "[MAJOR]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-major.png 'Severity: MAJOR'";
+      + "[MAJOR]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-major.png 'Severity: MAJOR'";
 
     String formattedGlobalReport = globalReport.formatForMarkdown();
 

--- a/src/test/java/org/sonar/plugins/github/MarkDownReportBuilderTest.java
+++ b/src/test/java/org/sonar/plugins/github/MarkDownReportBuilderTest.java
@@ -51,7 +51,7 @@ public class MarkDownReportBuilderTest {
     assertThat(builder.toString()).isEqualTo("![BLOCKER][BLOCKER] fix the leak!\n"
       + "Check comments too!\n"
       + "\n"
-      + "[BLOCKER]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'");
+      + "[BLOCKER]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'");
   }
 
   @Test
@@ -64,7 +64,7 @@ public class MarkDownReportBuilderTest {
       + "![BLOCKER][BLOCKER] fix the leak!\n"
       + "Check comments too!\n"
       + "\n"
-      + "[BLOCKER]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'");
+      + "[BLOCKER]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'");
   }
 
   @Test
@@ -79,11 +79,11 @@ public class MarkDownReportBuilderTest {
       + "![CRITICAL][CRITICAL] a CRITICAL-level issue\n"
       + "![BLOCKER][BLOCKER] a BLOCKER-level issue\n"
       + "\n"
-      + "[BLOCKER]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'\n"
-      + "[CRITICAL]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-critical.png 'Severity: CRITICAL'\n"
-      + "[INFO]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-info.png 'Severity: INFO'\n"
-      + "[MAJOR]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-major.png 'Severity: MAJOR'\n"
-      + "[MINOR]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-minor.png 'Severity: MINOR'");
+      + "[BLOCKER]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'\n"
+      + "[CRITICAL]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-critical.png 'Severity: CRITICAL'\n"
+      + "[INFO]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-info.png 'Severity: INFO'\n"
+      + "[MAJOR]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-major.png 'Severity: MAJOR'\n"
+      + "[MINOR]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-minor.png 'Severity: MINOR'");
   }
 
   @Test
@@ -104,8 +104,8 @@ public class MarkDownReportBuilderTest {
       + "\n"
       + "Check comments too!\n"
       + "\n"
-      + "[BLOCKER]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'\n"
-      + "[INFO]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-info.png 'Severity: INFO'");
+      + "[BLOCKER]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'\n"
+      + "[INFO]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-info.png 'Severity: INFO'");
   }
 
   @Test
@@ -122,6 +122,6 @@ public class MarkDownReportBuilderTest {
     assertThat(builder.toString()).isEqualTo("![BLOCKER][BLOCKER] fix the leak!\n"
       + "Check comments too!\n"
       + "\n"
-      + "[BLOCKER]: https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'");
+      + "[BLOCKER]: https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/severity-blocker.png 'Severity: BLOCKER'");
   }
 }

--- a/src/test/java/org/sonar/plugins/github/PullRequestIssuePostJobTest.java
+++ b/src/test/java/org/sonar/plugins/github/PullRequestIssuePostJobTest.java
@@ -132,7 +132,7 @@ public class PullRequestIssuePostJobTest {
     verify(pullRequestFacade)
       .createOrUpdateGlobalComments(
         contains(
-          "1. ![BLOCKER][BLOCKER] [Foo.php#L2](http://github/blob/abc123/src/Foo.php#L2): msg2 [![rule](https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule)"));
+          "1. ![BLOCKER][BLOCKER] [Foo.php#L2](http://github/blob/abc123/src/Foo.php#L2): msg2 [![rule](https://raw.githubusercontent.com/SonarSource/sonar-github/master/images/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule)"));
 
     verify(pullRequestFacade).createOrUpdateSonarQubeStatus(GHCommitState.ERROR, "SonarQube reported 5 issues, with 5 blocker");
   }


### PR DESCRIPTION
Currently images in the PR are not working (https://raw.githubusercontent.com/SonarCommunity/sonar-github/master/images/severity-minor.png) - this is most probably due to the renaming of the git org.

Searched & replaced all references (including tests) - there are still some other references but they don't seem to be that important (config tests) - e.g. one test is failing but also failing on other PRs so unrelated?