### PR TITLE
Encode spaces in github url

### DIFF
--- a/src/main/java/org/sonar/plugins/github/MarkDownUtils.java
+++ b/src/main/java/org/sonar/plugins/github/MarkDownUtils.java
@@ -70,7 +70,7 @@ public class MarkDownUtils {
   public String globalIssue(String message, String ruleKey, @Nullable String url, String componentKey) {
     StringBuilder sb = new StringBuilder();
     if (url != null) {
-      sb.append("[").append(getLocation(url)).append("]").append("(").append(url).append(")");
+      sb.append("[").append(getLocation(url)).append("]").append("(").append(encodeSpacesForUrl(url)).append(")");
     } else {
       sb.append(componentKey);
     }
@@ -81,6 +81,10 @@ public class MarkDownUtils {
 
   String getRuleLink(String ruleKey) {
     return "[![rule](" + IMAGES_ROOT_URL + "rule.png)](" + ruleUrlPrefix + "coding_rules#rule_key=" + encodeForUrl(ruleKey) + ")";
+  }
+
+  static String encodeSpacesForUrl(String url) {
+    return url.replaceAll(" ","%20");
   }
 
   static String encodeForUrl(String url) {


### PR DESCRIPTION
The problem is that github does not render properly links to files wth spaces in comments. The solution is to escape spaces with '%20' to have working links.

Example with the issue:
1. ![MINOR][MINOR] [SomeClass.m#L242](https://github.com/SomeRepo/src/my folder/SomeClass.m#L242): Unnecessary else statement [![rule](https://sonarsource.github.io/sonar-github/rule.png)]

Example with the issue fixed:
1. ![MINOR][MINOR] [SomeClass.m#L242](https://github.com/SomeRepo/src/my%20folder/SomeClass.m#L242): Unnecessary else statement [![rule](https://sonarsource.github.io/sonar-github/rule.png)]