### PR TITLE
Add project ID to SonarQube GitHub comments

### DIFF
--- a/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
@@ -59,13 +59,7 @@ import org.sonar.api.PropertyType;
     description = "Issues will not be reported as inline comments but only in the global summary comment",
     project = true,
     global = true,
-    type = PropertyType.BOOLEAN),
-  @Property(
-    key = GitHubPlugin.GITHUB_PROJECT_ID,
-    name = "Project id",
-    description = "Project id used to distinguish between comments from different SonarQube projects",
-    project = true,
-    global = true)
+    type = PropertyType.BOOLEAN)
 })
 public class GitHubPlugin implements Plugin {
 
@@ -74,7 +68,6 @@ public class GitHubPlugin implements Plugin {
   public static final String GITHUB_REPO = "sonar.github.repository";
   public static final String GITHUB_PULL_REQUEST = "sonar.github.pullRequest";
   public static final String GITHUB_DISABLE_INLINE_COMMENTS = "sonar.github.disableInlineComments";
-  public static final String GITHUB_PROJECT_ID = "sonar.github.projectId";
 
 
   @Override

--- a/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
@@ -59,7 +59,13 @@ import org.sonar.api.PropertyType;
     description = "Issues will not be reported as inline comments but only in the global summary comment",
     project = true,
     global = true,
-    type = PropertyType.BOOLEAN)
+    type = PropertyType.BOOLEAN),
+  @Property(
+    key = GitHubPlugin.GITHUB_PROJECT_ID,
+    name = "Project id",
+    description = "Project id used to distinguish between comments from different SonarQube projects",
+    project = true,
+    global = true)
 })
 public class GitHubPlugin implements Plugin {
 
@@ -68,6 +74,7 @@ public class GitHubPlugin implements Plugin {
   public static final String GITHUB_REPO = "sonar.github.repository";
   public static final String GITHUB_PULL_REQUEST = "sonar.github.pullRequest";
   public static final String GITHUB_DISABLE_INLINE_COMMENTS = "sonar.github.disableInlineComments";
+  public static final String GITHUB_PROJECT_ID = "sonar.github.projectId";
 
 
   @Override

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -136,6 +136,10 @@ public class GitHubPluginConfiguration {
     return !settings.getBoolean(GitHubPlugin.GITHUB_DISABLE_INLINE_COMMENTS);
   }
 
+  public String projectId() {
+    return settings.getString(GitHubPlugin.GITHUB_PROJECT_ID);
+  }
+
   /**
    * Checks if a proxy was passed with command line parameters or configured in the system.
    * If only an HTTP proxy was configured then it's properties are copied to the HTTPS proxy (like SonarQube configuration)

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -28,6 +28,7 @@ import java.net.URISyntaxException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 import org.sonar.api.CoreProperties;
 import org.sonar.api.batch.BatchSide;
 import org.sonar.api.batch.InstantiationStrategy;
@@ -136,8 +137,8 @@ public class GitHubPluginConfiguration {
     return !settings.getBoolean(GitHubPlugin.GITHUB_DISABLE_INLINE_COMMENTS);
   }
 
-  public String projectId() {
-    return settings.getString(GitHubPlugin.GITHUB_PROJECT_ID);
+  public @Nullable String projectKey() {
+    return settings.getString("sonar.projectKey");
   }
 
   /**

--- a/src/main/java/org/sonar/plugins/github/GlobalReport.java
+++ b/src/main/java/org/sonar/plugins/github/GlobalReport.java
@@ -32,17 +32,17 @@ public class GlobalReport {
   private int[] newIssuesBySeverity = new int[Severity.values().length];
   private int extraIssueCount = 0;
   private int maxGlobalReportedIssues;
-  private String projectId;
+  private String projectKey;
   private final ReportBuilder builder;
 
-  public GlobalReport(MarkDownUtils markDownUtils, boolean tryReportIssuesInline, String projectId) {
-    this(markDownUtils, tryReportIssuesInline, GitHubPluginConfiguration.MAX_GLOBAL_ISSUES, projectId);
+  public GlobalReport(MarkDownUtils markDownUtils, boolean tryReportIssuesInline, @Nullable String projectKey) {
+    this(markDownUtils, tryReportIssuesInline, GitHubPluginConfiguration.MAX_GLOBAL_ISSUES, projectKey);
   }
 
-  public GlobalReport(MarkDownUtils markDownUtils, boolean tryReportIssuesInline, int maxGlobalReportedIssues, String projectId) {
+  public GlobalReport(MarkDownUtils markDownUtils, boolean tryReportIssuesInline, int maxGlobalReportedIssues, @Nullable String projectKey) {
     this.tryReportIssuesInline = tryReportIssuesInline;
     this.maxGlobalReportedIssues = maxGlobalReportedIssues;
-    this.projectId = projectId;
+    this.projectKey = projectKey;
     this.builder = new MarkDownReportBuilder(markDownUtils);
   }
 
@@ -55,15 +55,14 @@ public class GlobalReport {
 
     boolean hasInlineIssues = newIssues > extraIssueCount;
     boolean extraIssuesTruncated = extraIssueCount > maxGlobalReportedIssues;
-    if (!StringUtils.isEmpty(projectId)) {
-      builder.appendProjectId(projectId).append(" ");
-    }
+
     if (newIssues == 0) {
-      builder.append("SonarQube analysis reported no issues.");
+      builder.append("SonarQube analysis reported no issues.").appendProjectId(projectKey);
       return builder.toString();
-    } else {
-      builder.append("SonarQube analysis reported ").append(newIssues).append(" issue").append(newIssues > 1 ? "s" : "").append("\n");
     }
+
+    builder.append("SonarQube analysis reported ").append(newIssues).append(" issue").append(newIssues > 1 ? "s" : "").append("\n");
+
     if (hasInlineIssues || extraIssuesTruncated) {
       appendSummaryBySeverity(builder);
     }
@@ -75,7 +74,7 @@ public class GlobalReport {
       appendExtraIssues(builder, hasInlineIssues, extraIssuesTruncated);
     }
 
-    return builder.toString();
+    return builder.appendProjectId(projectKey).toString();
   }
 
   private void appendExtraIssues(ReportBuilder builder, boolean hasInlineIssues, boolean extraIssuesTruncated) {

--- a/src/main/java/org/sonar/plugins/github/GlobalReport.java
+++ b/src/main/java/org/sonar/plugins/github/GlobalReport.java
@@ -21,6 +21,8 @@ package org.sonar.plugins.github;
 
 import java.util.Locale;
 import javax.annotation.Nullable;
+
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.github.GHCommitState;
 import org.sonar.api.batch.postjob.issue.PostJobIssue;
 import org.sonar.api.batch.rule.Severity;
@@ -30,15 +32,17 @@ public class GlobalReport {
   private int[] newIssuesBySeverity = new int[Severity.values().length];
   private int extraIssueCount = 0;
   private int maxGlobalReportedIssues;
+  private String projectId;
   private final ReportBuilder builder;
 
-  public GlobalReport(MarkDownUtils markDownUtils, boolean tryReportIssuesInline) {
-    this(markDownUtils, tryReportIssuesInline, GitHubPluginConfiguration.MAX_GLOBAL_ISSUES);
+  public GlobalReport(MarkDownUtils markDownUtils, boolean tryReportIssuesInline, String projectId) {
+    this(markDownUtils, tryReportIssuesInline, GitHubPluginConfiguration.MAX_GLOBAL_ISSUES, projectId);
   }
 
-  public GlobalReport(MarkDownUtils markDownUtils, boolean tryReportIssuesInline, int maxGlobalReportedIssues) {
+  public GlobalReport(MarkDownUtils markDownUtils, boolean tryReportIssuesInline, int maxGlobalReportedIssues, String projectId) {
     this.tryReportIssuesInline = tryReportIssuesInline;
     this.maxGlobalReportedIssues = maxGlobalReportedIssues;
+    this.projectId = projectId;
     this.builder = new MarkDownReportBuilder(markDownUtils);
   }
 
@@ -48,13 +52,18 @@ public class GlobalReport {
 
   public String formatForMarkdown() {
     int newIssues = newIssues(Severity.BLOCKER) + newIssues(Severity.CRITICAL) + newIssues(Severity.MAJOR) + newIssues(Severity.MINOR) + newIssues(Severity.INFO);
-    if (newIssues == 0) {
-      return "SonarQube analysis reported no issues.";
-    }
 
     boolean hasInlineIssues = newIssues > extraIssueCount;
     boolean extraIssuesTruncated = extraIssueCount > maxGlobalReportedIssues;
-    builder.append("SonarQube analysis reported ").append(newIssues).append(" issue").append(newIssues > 1 ? "s" : "").append("\n");
+    if (!StringUtils.isEmpty(projectId)) {
+      builder.appendProjectId(projectId).append(" ");
+    }
+    if (newIssues == 0) {
+      builder.append("SonarQube analysis reported no issues.");
+      return builder.toString();
+    } else {
+      builder.append("SonarQube analysis reported ").append(newIssues).append(" issue").append(newIssues > 1 ? "s" : "").append("\n");
+    }
     if (hasInlineIssues || extraIssuesTruncated) {
       appendSummaryBySeverity(builder);
     }

--- a/src/main/java/org/sonar/plugins/github/MarkDownReportBuilder.java
+++ b/src/main/java/org/sonar/plugins/github/MarkDownReportBuilder.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import org.apache.commons.lang.StringUtils;
 import org.sonar.api.batch.postjob.issue.PostJobIssue;
 import org.sonar.api.batch.rule.Severity;
 
@@ -52,7 +53,10 @@ public class MarkDownReportBuilder implements ReportBuilder {
 
   @Override
   public ReportBuilder appendProjectId(String projectId) {
-    sb.append(markDownUtils.projectId(projectId));
+    if (!StringUtils.isEmpty(projectId)) {
+      sb.append(MarkDownUtils.projectId(projectId));
+    }
+
     return this;
   }
 

--- a/src/main/java/org/sonar/plugins/github/MarkDownReportBuilder.java
+++ b/src/main/java/org/sonar/plugins/github/MarkDownReportBuilder.java
@@ -51,6 +51,12 @@ public class MarkDownReportBuilder implements ReportBuilder {
   }
 
   @Override
+  public ReportBuilder appendProjectId(String projectId) {
+    sb.append(markDownUtils.projectId(projectId));
+    return this;
+  }
+
+  @Override
   public ReportBuilder append(Object o) {
     sb.append(o);
     return this;

--- a/src/main/java/org/sonar/plugins/github/MarkDownUtils.java
+++ b/src/main/java/org/sonar/plugins/github/MarkDownUtils.java
@@ -47,6 +47,12 @@ public class MarkDownUtils {
     this.ruleUrlPrefix = baseUrl;
   }
 
+  public static String projectId(String projectId) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("[").append(projectId).append("]");
+    return sb.toString();
+  }
+
   public String inlineIssue(Severity severity, String message, String ruleKey) {
     String ruleLink = getRuleLink(ruleKey);
     StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/sonar/plugins/github/MarkDownUtils.java
+++ b/src/main/java/org/sonar/plugins/github/MarkDownUtils.java
@@ -49,7 +49,7 @@ public class MarkDownUtils {
 
   public static String projectId(String projectId) {
     StringBuilder sb = new StringBuilder();
-    sb.append("[").append(projectId).append("]");
+    sb.append("\n[project-id]: ").append(projectId);
     return sb.toString();
   }
 

--- a/src/main/java/org/sonar/plugins/github/PullRequestFacade.java
+++ b/src/main/java/org/sonar/plugins/github/PullRequestFacade.java
@@ -31,6 +31,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
+
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.github.GHCommitState;
 import org.kohsuke.github.GHCommitStatus;
 import org.kohsuke.github.GHIssueComment;
@@ -72,6 +74,7 @@ public class PullRequestFacade {
 
   public PullRequestFacade(GitHubPluginConfiguration config) {
     this.config = config;
+
   }
 
   public void init(int pullRequestNumber, File projectBaseDir) {
@@ -134,6 +137,10 @@ public class PullRequestFacade {
     for (GHPullRequestReviewComment comment : pr.listReviewComments()) {
       if (!myself.equals(comment.getUser().getLogin())) {
         // Ignore comments from other users
+        continue;
+      }
+      if (!StringUtils.isEmpty(config.projectId()) && !comment.getBody().startsWith(MarkDownUtils.projectId(config.projectId()))) {
+        // Ignore comments that don't contain projectId
         continue;
       }
       if (!existingReviewCommentsByLocationByFile.containsKey(comment.getPath())) {
@@ -255,6 +262,10 @@ public class PullRequestFacade {
     boolean found = false;
     for (GHIssueComment comment : pr.listComments()) {
       if (myself.equals(comment.getUser().getLogin())) {
+        if (!StringUtils.isEmpty(config.projectId()) && !comment.getBody().startsWith(MarkDownUtils.projectId(config.projectId()))) {
+          // Ignore comments that don't contain projectId
+          continue;
+        }
         if (markup == null || found || !markup.equals(comment.getBody())) {
           comment.delete();
           continue;

--- a/src/main/java/org/sonar/plugins/github/PullRequestFacade.java
+++ b/src/main/java/org/sonar/plugins/github/PullRequestFacade.java
@@ -139,12 +139,12 @@ public class PullRequestFacade {
         // Ignore comments from other users
         continue;
       }
-      if (!StringUtils.isEmpty(config.projectId()) && !comment.getBody().startsWith(MarkDownUtils.projectId(config.projectId()))) {
+      if (!StringUtils.isEmpty(config.projectKey()) && !comment.getBody().contains(MarkDownUtils.projectId(config.projectKey()))) {
         // Ignore comments that don't contain projectId
         continue;
       }
       if (!existingReviewCommentsByLocationByFile.containsKey(comment.getPath())) {
-        existingReviewCommentsByLocationByFile.put(comment.getPath(), new HashMap<Integer, GHPullRequestReviewComment>());
+        existingReviewCommentsByLocationByFile.put(comment.getPath(), new HashMap<>());
       }
       // By default all previous comments will be marked for deletion
       reviewCommentToBeDeletedById.put(comment.getId(), comment);
@@ -262,7 +262,7 @@ public class PullRequestFacade {
     boolean found = false;
     for (GHIssueComment comment : pr.listComments()) {
       if (myself.equals(comment.getUser().getLogin())) {
-        if (!StringUtils.isEmpty(config.projectId()) && !comment.getBody().startsWith(MarkDownUtils.projectId(config.projectId()))) {
+        if (!StringUtils.isEmpty(config.projectKey()) && !comment.getBody().contains(MarkDownUtils.projectId(config.projectKey()))) {
           // Ignore comments that don't contain projectId
           continue;
         }

--- a/src/main/java/org/sonar/plugins/github/PullRequestIssuePostJob.java
+++ b/src/main/java/org/sonar/plugins/github/PullRequestIssuePostJob.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.StreamSupport;
+import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
 
 import org.kohsuke.github.GHCommitState;
@@ -62,9 +63,11 @@ public class PullRequestIssuePostJob implements PostJob {
 
   @Override
   public void execute(PostJobContext context) {
-    GlobalReport report = new GlobalReport(markDownUtils, gitHubPluginConfiguration.tryReportIssuesInline(), gitHubPluginConfiguration.projectId());
+    String projectKey = gitHubPluginConfiguration.projectKey();
+
+    GlobalReport report = new GlobalReport(markDownUtils, gitHubPluginConfiguration.tryReportIssuesInline(), projectKey);
     try {
-      Map<InputFile, Map<Integer, StringBuilder>> commentsToBeAddedByLine = processIssues(report, context.issues());
+      Map<InputFile, Map<Integer, StringBuilder>> commentsToBeAddedByLine = processIssues(report, context.issues(), projectKey);
 
       updateReviewComments(commentsToBeAddedByLine);
 
@@ -79,7 +82,8 @@ public class PullRequestIssuePostJob implements PostJob {
     }
   }
 
-  private Map<InputFile, Map<Integer, StringBuilder>> processIssues(GlobalReport report, Iterable<PostJobIssue> issues) {
+  private Map<InputFile, Map<Integer, StringBuilder>> processIssues(
+          GlobalReport report, Iterable<PostJobIssue> issues, @Nullable String projectKey) {
     Map<InputFile, Map<Integer, StringBuilder>> commentToBeAddedByFileAndByLine = new HashMap<>();
 
     StreamSupport.stream(issues.spliterator(), false)
@@ -92,21 +96,21 @@ public class PullRequestIssuePostJob implements PostJob {
           pullRequestFacade.hasFile((InputFile) inputComponent);
       })
       .sorted(ISSUE_COMPARATOR)
-      .forEach(i -> processIssue(report, commentToBeAddedByFileAndByLine, i));
+      .forEach(i -> processIssue(report, commentToBeAddedByFileAndByLine, i, projectKey));
     return commentToBeAddedByFileAndByLine;
 
   }
 
-  private void processIssue(GlobalReport report, Map<InputFile, Map<Integer, StringBuilder>> commentToBeAddedByFileAndByLine, PostJobIssue issue) {
+  private void processIssue(GlobalReport report, Map<InputFile, Map<Integer, StringBuilder>> commentToBeAddedByFileAndByLine, PostJobIssue issue, @Nullable String projectKey) {
     boolean reportedInline = false;
     InputComponent inputComponent = issue.inputComponent();
     if (gitHubPluginConfiguration.tryReportIssuesInline() && inputComponent != null && inputComponent.isFile()) {
-      reportedInline = tryReportInline(commentToBeAddedByFileAndByLine, issue, (InputFile) inputComponent);
+      reportedInline = tryReportInline(commentToBeAddedByFileAndByLine, issue, (InputFile) inputComponent, projectKey);
     }
     report.process(issue, pullRequestFacade.getGithubUrl(inputComponent, issue.line()), reportedInline);
   }
 
-  private boolean tryReportInline(Map<InputFile, Map<Integer, StringBuilder>> commentToBeAddedByFileAndByLine, PostJobIssue issue, InputFile inputFile) {
+  private boolean tryReportInline(Map<InputFile, Map<Integer, StringBuilder>> commentToBeAddedByFileAndByLine, PostJobIssue issue, InputFile inputFile, @Nullable String projectKey) {
     Integer lineOrNull = issue.line();
     if (lineOrNull != null) {
       int line = lineOrNull.intValue();
@@ -114,17 +118,21 @@ public class PullRequestIssuePostJob implements PostJob {
         String message = issue.message();
         String ruleKey = issue.ruleKey().toString();
         if (!commentToBeAddedByFileAndByLine.containsKey(inputFile)) {
-          commentToBeAddedByFileAndByLine.put(inputFile, new HashMap<Integer, StringBuilder>());
+          commentToBeAddedByFileAndByLine.put(inputFile, new HashMap<>());
         }
         Map<Integer, StringBuilder> commentsByLine = commentToBeAddedByFileAndByLine.get(inputFile);
+
         if (!commentsByLine.containsKey(line)) {
           StringBuilder stringBuilder = new StringBuilder();
-          if (!StringUtils.isEmpty(gitHubPluginConfiguration.projectId())) {
-            stringBuilder.append(markDownUtils.projectId(gitHubPluginConfiguration.projectId())).append("\n");
-          }
           commentsByLine.put(line, stringBuilder);
         }
+
         commentsByLine.get(line).append(markDownUtils.inlineIssue(issue.severity(), message, ruleKey)).append("\n");
+
+        if (!StringUtils.isEmpty(projectKey)) {
+          commentsByLine.get(line).append(MarkDownUtils.projectId(projectKey)).append("\n");
+        }
+
         return true;
       }
     }

--- a/src/main/java/org/sonar/plugins/github/PullRequestIssuePostJob.java
+++ b/src/main/java/org/sonar/plugins/github/PullRequestIssuePostJob.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.StreamSupport;
 import org.apache.commons.lang.StringUtils;
+
 import org.kohsuke.github.GHCommitState;
 import org.sonar.api.batch.fs.InputComponent;
 import org.sonar.api.batch.fs.InputFile;
@@ -61,7 +62,7 @@ public class PullRequestIssuePostJob implements PostJob {
 
   @Override
   public void execute(PostJobContext context) {
-    GlobalReport report = new GlobalReport(markDownUtils, gitHubPluginConfiguration.tryReportIssuesInline());
+    GlobalReport report = new GlobalReport(markDownUtils, gitHubPluginConfiguration.tryReportIssuesInline(), gitHubPluginConfiguration.projectId());
     try {
       Map<InputFile, Map<Integer, StringBuilder>> commentsToBeAddedByLine = processIssues(report, context.issues());
 
@@ -117,7 +118,11 @@ public class PullRequestIssuePostJob implements PostJob {
         }
         Map<Integer, StringBuilder> commentsByLine = commentToBeAddedByFileAndByLine.get(inputFile);
         if (!commentsByLine.containsKey(line)) {
-          commentsByLine.put(line, new StringBuilder());
+          StringBuilder stringBuilder = new StringBuilder();
+          if (!StringUtils.isEmpty(gitHubPluginConfiguration.projectId())) {
+            stringBuilder.append(markDownUtils.projectId(gitHubPluginConfiguration.projectId())).append("\n");
+          }
+          commentsByLine.put(line, stringBuilder);
         }
         commentsByLine.get(line).append(markDownUtils.inlineIssue(issue.severity(), message, ruleKey)).append("\n");
         return true;

--- a/src/main/java/org/sonar/plugins/github/ReportBuilder.java
+++ b/src/main/java/org/sonar/plugins/github/ReportBuilder.java
@@ -25,6 +25,14 @@ import org.sonar.api.batch.rule.Severity;
 
 public interface ReportBuilder {
   /**
+   * Append project id to the report.
+   *
+   * @param projectId Project id to append
+   * @return a reference to this object
+     */
+  ReportBuilder appendProjectId(String projectId);
+
+  /**
    * Append an object to the report, using its toString() method.
    *
    * @param o object to append

--- a/src/test/java/org/sonar/plugins/github/GlobalReportTest.java
+++ b/src/test/java/org/sonar/plugins/github/GlobalReportTest.java
@@ -71,7 +71,7 @@ public class GlobalReportTest {
 
   @Test
   public void noIssues() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true);
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "");
 
     String desiredMarkdown = "SonarQube analysis reported no issues.";
 
@@ -81,8 +81,19 @@ public class GlobalReportTest {
   }
 
   @Test
+  public void noIssuesWithProjectId() {
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "project-id");
+
+    String desiredMarkdown = "[project-id] SonarQube analysis reported no issues.";
+
+    String formattedGlobalReport = globalReport.formatForMarkdown();
+
+    assertThat(formattedGlobalReport).isEqualTo(desiredMarkdown);
+  }
+
+  @Test
   public void oneIssue() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true);
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "");
     globalReport.process(newMockedIssue("component", null, null, Severity.INFO, true, "Issue", "rule"), GITHUB_URL, true);
 
     String desiredMarkdown = "SonarQube analysis reported 1 issue\n" +
@@ -96,8 +107,23 @@ public class GlobalReportTest {
   }
 
   @Test
+  public void oneIssueWithProjectId() {
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "project-id");
+    globalReport.process(newMockedIssue("component", null, null, Severity.INFO, true, "Issue", "rule"), GITHUB_URL, true);
+
+    String desiredMarkdown = "[project-id] SonarQube analysis reported 1 issue\n" +
+            "* ![INFO][INFO] 1 info\n" +
+            "\nWatch the comments in this conversation to review them.\n" +
+            "\n[INFO]: https://sonarsource.github.io/sonar-github/severity-info.png 'Severity: INFO'";
+
+    String formattedGlobalReport = globalReport.formatForMarkdown();
+
+    assertThat(formattedGlobalReport).isEqualTo(desiredMarkdown);
+  }
+
+  @Test
   public void oneIssueOnDir() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true);
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "");
     globalReport.process(newMockedIssue("component0", null, null, Severity.INFO, true, "Issue0", "rule0"), null, false);
 
     String desiredMarkdown = "SonarQube analysis reported 1 issue\n\n" +
@@ -113,7 +139,7 @@ public class GlobalReportTest {
 
   @Test
   public void shouldFormatIssuesForMarkdownNoInline() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true);
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "");
     globalReport.process(newMockedIssue("component", null, null, Severity.INFO, true, "Issue", "rule"), GITHUB_URL, true);
     globalReport.process(newMockedIssue("component", null, null, Severity.MINOR, true, "Issue", "rule"), GITHUB_URL, true);
     globalReport.process(newMockedIssue("component", null, null, Severity.MAJOR, true, "Issue", "rule"), GITHUB_URL, true);
@@ -141,7 +167,7 @@ public class GlobalReportTest {
 
   @Test
   public void shouldFormatIssuesForMarkdownMixInlineGlobal() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true);
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "");
     globalReport.process(newMockedIssue("component", null, null, Severity.INFO, true, "Issue 0", "rule0"), GITHUB_URL, true);
     globalReport.process(newMockedIssue("component", null, null, Severity.MINOR, true, "Issue 1", "rule1"), GITHUB_URL, false);
     globalReport.process(newMockedIssue("component", null, null, Severity.MAJOR, true, "Issue 2", "rule2"), GITHUB_URL, true);
@@ -175,7 +201,7 @@ public class GlobalReportTest {
 
   @Test
   public void shouldFormatIssuesForMarkdownWhenInlineCommentsDisabled() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), false);
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), false, "");
     globalReport.process(newMockedIssue("component", null, null, Severity.INFO, true, "Issue 0", "rule0"), GITHUB_URL, false);
     globalReport.process(newMockedIssue("component", null, null, Severity.MINOR, true, "Issue 1", "rule1"), GITHUB_URL, false);
     globalReport.process(newMockedIssue("component", null, null, Severity.MAJOR, true, "Issue 2", "rule2"), GITHUB_URL, false);
@@ -206,7 +232,7 @@ public class GlobalReportTest {
 
   @Test
   public void shouldFormatIssuesForMarkdownWhenInlineCommentsDisabledAndLimitReached() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), false, 4);
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), false, 4, "");
     globalReport.process(newMockedIssue("component", null, null, Severity.INFO, true, "Issue 0", "rule0"), GITHUB_URL, false);
     globalReport.process(newMockedIssue("component", null, null, Severity.MINOR, true, "Issue 1", "rule1"), GITHUB_URL, false);
     globalReport.process(newMockedIssue("component", null, null, Severity.MAJOR, true, "Issue 2", "rule2"), GITHUB_URL, false);
@@ -241,7 +267,7 @@ public class GlobalReportTest {
 
   @Test
   public void shouldLimitGlobalIssues() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true);
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "");
     for (int i = 0; i < 17; i++) {
       globalReport.process(newMockedIssue("component", null, null, Severity.MAJOR, true, "Issue number:" + i, "rule" + i), GITHUB_URL + "/File.java#L" + i, false);
     }
@@ -280,7 +306,7 @@ public class GlobalReportTest {
 
   @Test
   public void shouldLimitGlobalIssuesWhenInlineCommentsDisabled() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), false);
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), false, "");
     for (int i = 0; i < 17; i++) {
       globalReport.process(newMockedIssue("component", null, null, Severity.MAJOR, true, "Issue number:" + i, "rule" + i), GITHUB_URL + "/File.java#L" + i, false);
     }

--- a/src/test/java/org/sonar/plugins/github/GlobalReportTest.java
+++ b/src/test/java/org/sonar/plugins/github/GlobalReportTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class GlobalReportTest {
-
+  private static final String PROJECT_KEY = "test.key";
   private static final String GITHUB_URL = "https://github.com/SonarSource/sonar-github";
 
   private Settings settings;
@@ -70,36 +70,10 @@ public class GlobalReportTest {
   }
 
   @Test
-  public void noIssues() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "");
-
-    String desiredMarkdown = "SonarQube analysis reported no issues.";
-
-    String formattedGlobalReport = globalReport.formatForMarkdown();
-
-    assertThat(formattedGlobalReport).isEqualTo(desiredMarkdown);
-  }
-
-  @Test
   public void noIssuesWithProjectId() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "project-id");
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, PROJECT_KEY);
 
-    String desiredMarkdown = "[project-id] SonarQube analysis reported no issues.";
-
-    String formattedGlobalReport = globalReport.formatForMarkdown();
-
-    assertThat(formattedGlobalReport).isEqualTo(desiredMarkdown);
-  }
-
-  @Test
-  public void oneIssue() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "");
-    globalReport.process(newMockedIssue("component", null, null, Severity.INFO, true, "Issue", "rule"), GITHUB_URL, true);
-
-    String desiredMarkdown = "SonarQube analysis reported 1 issue\n" +
-      "* ![INFO][INFO] 1 info\n" +
-      "\nWatch the comments in this conversation to review them.\n" +
-      "\n[INFO]: https://sonarsource.github.io/sonar-github/severity-info.png 'Severity: INFO'";
+    String desiredMarkdown = "SonarQube analysis reported no issues.\n[project-id]: test.key";
 
     String formattedGlobalReport = globalReport.formatForMarkdown();
 
@@ -108,12 +82,13 @@ public class GlobalReportTest {
 
   @Test
   public void oneIssueWithProjectId() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "project-id");
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, PROJECT_KEY);
     globalReport.process(newMockedIssue("component", null, null, Severity.INFO, true, "Issue", "rule"), GITHUB_URL, true);
 
-    String desiredMarkdown = "[project-id] SonarQube analysis reported 1 issue\n" +
+    String desiredMarkdown = "SonarQube analysis reported 1 issue\n" +
             "* ![INFO][INFO] 1 info\n" +
             "\nWatch the comments in this conversation to review them.\n" +
+            "\n[project-id]: test.key" +
             "\n[INFO]: https://sonarsource.github.io/sonar-github/severity-info.png 'Severity: INFO'";
 
     String formattedGlobalReport = globalReport.formatForMarkdown();
@@ -123,13 +98,14 @@ public class GlobalReportTest {
 
   @Test
   public void oneIssueOnDir() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "");
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, PROJECT_KEY);
     globalReport.process(newMockedIssue("component0", null, null, Severity.INFO, true, "Issue0", "rule0"), null, false);
 
     String desiredMarkdown = "SonarQube analysis reported 1 issue\n\n" +
       "Note: The following issues were found on lines that were not modified in the pull request. Because these issues can't be reported as line comments, they are summarized here:\n\n"
       +
       "1. ![INFO][INFO] component0: Issue0 [![rule](https://sonarsource.github.io/sonar-github/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule0)\n" +
+      "\n[project-id]: test.key" +
       "\n[INFO]: https://sonarsource.github.io/sonar-github/severity-info.png 'Severity: INFO'";
 
     String formattedGlobalReport = globalReport.formatForMarkdown();
@@ -139,7 +115,7 @@ public class GlobalReportTest {
 
   @Test
   public void shouldFormatIssuesForMarkdownNoInline() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "");
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, PROJECT_KEY);
     globalReport.process(newMockedIssue("component", null, null, Severity.INFO, true, "Issue", "rule"), GITHUB_URL, true);
     globalReport.process(newMockedIssue("component", null, null, Severity.MINOR, true, "Issue", "rule"), GITHUB_URL, true);
     globalReport.process(newMockedIssue("component", null, null, Severity.MAJOR, true, "Issue", "rule"), GITHUB_URL, true);
@@ -154,6 +130,7 @@ public class GlobalReportTest {
       "* ![INFO][INFO] 1 info\n" +
       "\nWatch the comments in this conversation to review them.\n"
       + "\n"
+      + "[project-id]: test.key\n"
       + "[BLOCKER]: https://sonarsource.github.io/sonar-github/severity-blocker.png 'Severity: BLOCKER'\n"
       + "[CRITICAL]: https://sonarsource.github.io/sonar-github/severity-critical.png 'Severity: CRITICAL'\n"
       + "[INFO]: https://sonarsource.github.io/sonar-github/severity-info.png 'Severity: INFO'\n"
@@ -167,7 +144,7 @@ public class GlobalReportTest {
 
   @Test
   public void shouldFormatIssuesForMarkdownMixInlineGlobal() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "");
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, PROJECT_KEY);
     globalReport.process(newMockedIssue("component", null, null, Severity.INFO, true, "Issue 0", "rule0"), GITHUB_URL, true);
     globalReport.process(newMockedIssue("component", null, null, Severity.MINOR, true, "Issue 1", "rule1"), GITHUB_URL, false);
     globalReport.process(newMockedIssue("component", null, null, Severity.MAJOR, true, "Issue 2", "rule2"), GITHUB_URL, true);
@@ -188,6 +165,7 @@ public class GlobalReportTest {
       +
       "1. ![CRITICAL][CRITICAL] [sonar-github](https://github.com/SonarSource/sonar-github): Issue 3 [![rule](https://sonarsource.github.io/sonar-github/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule3)\n"
       + "\n"
+      + "[project-id]: test.key\n"
       + "[BLOCKER]: https://sonarsource.github.io/sonar-github/severity-blocker.png 'Severity: BLOCKER'\n"
       + "[CRITICAL]: https://sonarsource.github.io/sonar-github/severity-critical.png 'Severity: CRITICAL'\n"
       + "[INFO]: https://sonarsource.github.io/sonar-github/severity-info.png 'Severity: INFO'\n"
@@ -201,7 +179,7 @@ public class GlobalReportTest {
 
   @Test
   public void shouldFormatIssuesForMarkdownWhenInlineCommentsDisabled() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), false, "");
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), false, PROJECT_KEY);
     globalReport.process(newMockedIssue("component", null, null, Severity.INFO, true, "Issue 0", "rule0"), GITHUB_URL, false);
     globalReport.process(newMockedIssue("component", null, null, Severity.MINOR, true, "Issue 1", "rule1"), GITHUB_URL, false);
     globalReport.process(newMockedIssue("component", null, null, Severity.MAJOR, true, "Issue 2", "rule2"), GITHUB_URL, false);
@@ -219,6 +197,7 @@ public class GlobalReportTest {
       +
       "1. ![BLOCKER][BLOCKER] [sonar-github](https://github.com/SonarSource/sonar-github): Issue 4 [![rule](https://sonarsource.github.io/sonar-github/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule4)\n"
       + "\n"
+      + "[project-id]: test.key\n"
       + "[BLOCKER]: https://sonarsource.github.io/sonar-github/severity-blocker.png 'Severity: BLOCKER'\n"
       + "[CRITICAL]: https://sonarsource.github.io/sonar-github/severity-critical.png 'Severity: CRITICAL'\n"
       + "[INFO]: https://sonarsource.github.io/sonar-github/severity-info.png 'Severity: INFO'\n"
@@ -232,7 +211,7 @@ public class GlobalReportTest {
 
   @Test
   public void shouldFormatIssuesForMarkdownWhenInlineCommentsDisabledAndLimitReached() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), false, 4, "");
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), false, 4, PROJECT_KEY);
     globalReport.process(newMockedIssue("component", null, null, Severity.INFO, true, "Issue 0", "rule0"), GITHUB_URL, false);
     globalReport.process(newMockedIssue("component", null, null, Severity.MINOR, true, "Issue 1", "rule1"), GITHUB_URL, false);
     globalReport.process(newMockedIssue("component", null, null, Severity.MAJOR, true, "Issue 2", "rule2"), GITHUB_URL, false);
@@ -254,6 +233,7 @@ public class GlobalReportTest {
       +
       "1. ![CRITICAL][CRITICAL] [sonar-github](https://github.com/SonarSource/sonar-github): Issue 3 [![rule](https://sonarsource.github.io/sonar-github/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule3)\n"
       + "\n"
+      + "[project-id]: test.key\n"
       + "[BLOCKER]: https://sonarsource.github.io/sonar-github/severity-blocker.png 'Severity: BLOCKER'\n"
       + "[CRITICAL]: https://sonarsource.github.io/sonar-github/severity-critical.png 'Severity: CRITICAL'\n"
       + "[INFO]: https://sonarsource.github.io/sonar-github/severity-info.png 'Severity: INFO'\n"
@@ -267,7 +247,7 @@ public class GlobalReportTest {
 
   @Test
   public void shouldLimitGlobalIssues() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, "");
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), true, PROJECT_KEY);
     for (int i = 0; i < 17; i++) {
       globalReport.process(newMockedIssue("component", null, null, Severity.MAJOR, true, "Issue number:" + i, "rule" + i), GITHUB_URL + "/File.java#L" + i, false);
     }
@@ -297,6 +277,7 @@ public class GlobalReportTest {
       +
       "1. ![MAJOR][MAJOR] [File.java#L9](https://github.com/SonarSource/sonar-github/File.java#L9): Issue number:9 [![rule](https://sonarsource.github.io/sonar-github/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule9)\n"
       + "\n"
+      + "[project-id]: test.key\n"
       + "[MAJOR]: https://sonarsource.github.io/sonar-github/severity-major.png 'Severity: MAJOR'";
 
     String formattedGlobalReport = globalReport.formatForMarkdown();
@@ -306,7 +287,7 @@ public class GlobalReportTest {
 
   @Test
   public void shouldLimitGlobalIssuesWhenInlineCommentsDisabled() {
-    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), false, "");
+    GlobalReport globalReport = new GlobalReport(new MarkDownUtils(settings), false, PROJECT_KEY);
     for (int i = 0; i < 17; i++) {
       globalReport.process(newMockedIssue("component", null, null, Severity.MAJOR, true, "Issue number:" + i, "rule" + i), GITHUB_URL + "/File.java#L" + i, false);
     }
@@ -334,6 +315,7 @@ public class GlobalReportTest {
       +
       "1. ![MAJOR][MAJOR] [File.java#L9](https://github.com/SonarSource/sonar-github/File.java#L9): Issue number:9 [![rule](https://sonarsource.github.io/sonar-github/rule.png)](http://myserver/coding_rules#rule_key=repo%3Arule9)\n"
       + "\n"
+      + "[project-id]: test.key\n"
       + "[MAJOR]: https://sonarsource.github.io/sonar-github/severity-major.png 'Severity: MAJOR'";
 
     String formattedGlobalReport = globalReport.formatForMarkdown();

--- a/src/test/java/org/sonar/plugins/github/PullRequestIssuePostJobTest.java
+++ b/src/test/java/org/sonar/plugins/github/PullRequestIssuePostJobTest.java
@@ -56,17 +56,25 @@ public class PullRequestIssuePostJobTest {
   @Before
   public void prepare() throws Exception {
     pullRequestFacade = mock(PullRequestFacade.class);
-    Settings settings = new Settings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL)
-      .name("Server base URL")
-      .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
-      .category(CoreProperties.CATEGORY_GENERAL)
-      .defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE)
-      .build()));
+    Settings settings = new Settings(new PropertyDefinitions(
+      PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL)
+        .name("Server base URL")
+        .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
+        .category(CoreProperties.CATEGORY_GENERAL)
+        .defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE)
+        .build(),
+      PropertyDefinition.builder(GitHubPlugin.GITHUB_PROJECT_ID)
+        .name("Project Id")
+        .description("Project Id")
+        .category(CoreProperties.CATEGORY_GENERAL)
+        .defaultValue("")
+        .build()));
     GitHubPluginConfiguration config = new GitHubPluginConfiguration(settings, new System2());
     context = mock(PostJobContext.class);
 
     settings.setProperty("sonar.host.url", "http://192.168.0.1");
     settings.setProperty(CoreProperties.SERVER_BASE_URL, "http://myserver");
+    settings.setProperty(GitHubPlugin.GITHUB_PROJECT_ID, "project-id");
     pullRequestIssuePostJob = new PullRequestIssuePostJob(config, pullRequestFacade, new MarkDownUtils(settings));
   }
 

--- a/src/test/java/org/sonar/plugins/github/PullRequestIssuePostJobTest.java
+++ b/src/test/java/org/sonar/plugins/github/PullRequestIssuePostJobTest.java
@@ -63,7 +63,7 @@ public class PullRequestIssuePostJobTest {
         .category(CoreProperties.CATEGORY_GENERAL)
         .defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE)
         .build(),
-      PropertyDefinition.builder(GitHubPlugin.GITHUB_PROJECT_ID)
+      PropertyDefinition.builder(CoreProperties.PROJECT_KEY_PROPERTY)
         .name("Project Id")
         .description("Project Id")
         .category(CoreProperties.CATEGORY_GENERAL)
@@ -74,7 +74,7 @@ public class PullRequestIssuePostJobTest {
 
     settings.setProperty("sonar.host.url", "http://192.168.0.1");
     settings.setProperty(CoreProperties.SERVER_BASE_URL, "http://myserver");
-    settings.setProperty(GitHubPlugin.GITHUB_PROJECT_ID, "project-id");
+    settings.setProperty(CoreProperties.PROJECT_KEY_PROPERTY, "project-id");
     pullRequestIssuePostJob = new PullRequestIssuePostJob(config, pullRequestFacade, new MarkDownUtils(settings));
   }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/SonarSource/sonar-github/pull/31 , implementing @henryju 's request of using hidden project key instead of dedicated configuration parameter.

This improves support of multi-project analysis.