### PR TITLE
feat: allow configuration of allowed minor/major issues

### DIFF
--- a/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
@@ -59,7 +59,23 @@ import org.sonar.api.PropertyType;
     description = "Issues will not be reported as inline comments but only in the global summary comment",
     project = true,
     global = true,
-    type = PropertyType.BOOLEAN)
+    type = PropertyType.BOOLEAN),
+  @Property(
+    key = GitHubPlugin.GITHUB_ALLOWED_MINOR_ISSUES,
+    defaultValue = "-1",
+    name = "Allowed minor issues",
+    description = "If number of allowed minor issues is exceeded the commit state will be error",
+    project = true,
+    global = false,
+    type = PropertyType.INTEGER),
+  @Property(
+    key = GitHubPlugin.GITHUB_ALLOWED_MAJOR_ISSUES,
+    defaultValue = "-1",
+    name = "Allowed major issues",
+    description = "If number of allowed major issues is exceeded the commit state will be error",
+    project = true,
+    global = false,
+    type = PropertyType.INTEGER)
 })
 public class GitHubPlugin implements Plugin {
 
@@ -68,7 +84,8 @@ public class GitHubPlugin implements Plugin {
   public static final String GITHUB_REPO = "sonar.github.repository";
   public static final String GITHUB_PULL_REQUEST = "sonar.github.pullRequest";
   public static final String GITHUB_DISABLE_INLINE_COMMENTS = "sonar.github.disableInlineComments";
-
+  public static final String GITHUB_ALLOWED_MINOR_ISSUES = "sonar.github.allowedMinorIssues";
+  public static final String GITHUB_ALLOWED_MAJOR_ISSUES = "sonar.github.allowedMajorIssues";
 
   @Override
   public void define(Context context) {

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -137,6 +137,26 @@ public class GitHubPluginConfiguration {
   }
 
   /**
+   * Gets the number of allowed issues with with {@link org.sonar.api.rule.Severity#MINOR}.
+   * defaults to -1 if not configured, indicating that there is unlimited amount of minor issues allowed
+   *
+   * @return amount of allowed minor issues or -1 if not configured
+   */
+  public int getAllowedMinorIssues() {
+    return settings.getInt(GitHubPlugin.GITHUB_ALLOWED_MINOR_ISSUES);
+  }
+
+  /**
+   * Gets the number of allowed issues with {@link org.sonar.api.rule.Severity#MAJOR}.
+   * defaults to -1 if not configured, indicating that there is unlimited amount of major issues allowed
+   *
+   * @return amount of allowed major issues or -1 if not configured
+   */
+  public int getAllowedMajorIssues() {
+    return settings.getInt(GitHubPlugin.GITHUB_ALLOWED_MAJOR_ISSUES);
+  }
+
+  /**
    * Checks if a proxy was passed with command line parameters or configured in the system.
    * If only an HTTP proxy was configured then it's properties are copied to the HTTPS proxy (like SonarQube configuration)
    * @return True iff a proxy was configured to be used in the plugin.

--- a/src/main/java/org/sonar/plugins/github/PullRequestIssuePostJob.java
+++ b/src/main/java/org/sonar/plugins/github/PullRequestIssuePostJob.java
@@ -61,7 +61,7 @@ public class PullRequestIssuePostJob implements PostJob {
 
   @Override
   public void execute(PostJobContext context) {
-    GlobalReport report = new GlobalReport(markDownUtils, gitHubPluginConfiguration.tryReportIssuesInline());
+    GlobalReport report = new GlobalReport(markDownUtils, gitHubPluginConfiguration.tryReportIssuesInline(),gitHubPluginConfiguration.getAllowedMajorIssues(),gitHubPluginConfiguration.getAllowedMinorIssues());
     try {
       Map<InputFile, Map<Integer, StringBuilder>> commentsToBeAddedByLine = processIssues(report, context.issues());
 

--- a/src/test/java/org/sonar/plugins/github/PullRequestIssuePostJobTest.java
+++ b/src/test/java/org/sonar/plugins/github/PullRequestIssuePostJobTest.java
@@ -64,11 +64,15 @@ public class PullRequestIssuePostJobTest {
       .category(CoreProperties.CATEGORY_GENERAL)
       .defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE)
       .build()));
-    GitHubPluginConfiguration config = new GitHubPluginConfiguration(settings, new System2());
-    context = mock(PostJobContext.class);
 
+    settings.setProperty(GitHubPlugin.GITHUB_ALLOWED_MAJOR_ISSUES,-1);
+    settings.setProperty(GitHubPlugin.GITHUB_ALLOWED_MINOR_ISSUES,-1);
     settings.setProperty("sonar.host.url", "http://192.168.0.1");
     settings.setProperty(CoreProperties.SERVER_BASE_URL, "http://myserver");
+
+    GitHubPluginConfiguration config = new GitHubPluginConfiguration(settings, new System2());
+    context = mock(PostJobContext.class);
+    
     pullRequestIssuePostJob = new PullRequestIssuePostJob(config, pullRequestFacade, new MarkDownUtils(settings));
   }
 


### PR DESCRIPTION
Feature Description:
Allowing the configuration of Major and Minor issues limits to set the PR status to error.

Two new properties were made available:
*sonar.github.allowedMinorIssues* which defaults to -1 allowing backwards compatibility
*sonar.github.allowedMajorIssues* which defaults to -1 allowing backwards compatibility

**Reasoning:**
As mentioned earlier by @henryju on #30, this repository will not receive much attention with the pr review feature moving to the branch plugin.
We are currently running on a sonar 5.5.x version and are not able to update soon and can't use the branch plugin. So adding this feature to this plugin 
would be of great help for us and the change is small. So i gave it a try.

P.S.
I was not able to find contribution guidelines. I am happy to mend any issues