### PR TITLE
Changed COMMIT_CONTEXT to user defined variable

### DIFF
--- a/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
@@ -59,7 +59,16 @@ import org.sonar.api.PropertyType;
     description = "Issues will not be reported as inline comments but only in the global summary comment",
     project = true,
     global = true,
-    type = PropertyType.BOOLEAN)
+    type = PropertyType.BOOLEAN),
+  @Property(
+    key = GitHubPlugin.GITHUB_COMMIT_CONTEXT,
+    defaultValue = "sonarqube",
+    name = "GitHub Commit Context",
+    description = "GitHub commit context for this analysis. Useful if you have more than one SonarQube server",
+    global = false,
+    project = false,
+    module = false
+  )
 })
 public class GitHubPlugin implements Plugin {
 
@@ -68,6 +77,7 @@ public class GitHubPlugin implements Plugin {
   public static final String GITHUB_REPO = "sonar.github.repository";
   public static final String GITHUB_PULL_REQUEST = "sonar.github.pullRequest";
   public static final String GITHUB_DISABLE_INLINE_COMMENTS = "sonar.github.disableInlineComments";
+  public static final String GITHUB_COMMIT_CONTEXT = "sonar.github.commitContext";
 
   @Override
   public void define(Context context) {

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -137,6 +137,10 @@ public class GitHubPluginConfiguration {
     return !settings.getBoolean(GitHubPlugin.GITHUB_DISABLE_INLINE_COMMENTS);
   }
 
+  public String commitContext() {
+    return settings.getString(GitHubPlugin.GITHUB_COMMIT_CONTEXT);
+  }
+
   /**
    * Checks if a proxy was passed with command line parameters or configured in the system.
    * If only an HTTP proxy was configured then it's properties are copied to the HTTPS proxy (like SonarQube configuration)

--- a/src/test/java/org/sonar/plugins/github/PullRequestFacadeTest.java
+++ b/src/test/java/org/sonar/plugins/github/PullRequestFacadeTest.java
@@ -113,12 +113,13 @@ public class PullRequestFacadeTest {
     when(pr.getRepository()).thenReturn(ghRepo);
     when(pr.getHead().getSha()).thenReturn("abc123");
     when(ghRepo.listCommitStatuses(pr.getHead().getSha())).thenReturn(ghCommitStatuses);
-    assertThat(facade.getCommitStatusForContext(pr, PullRequestFacade.COMMIT_CONTEXT)).isNull();
+    assertThat(facade.getCommitStatusForContext(pr, facade.getGithubCommitContext())).isNull();
   }
 
   @Test
   public void testGetCommitStatusForContextWithOneCorrectStatus() throws IOException {
     PullRequestFacade facade = new PullRequestFacade(mock(GitHubPluginConfiguration.class));
+    facade.setCommitContext("sonarQubeContext");
     GHRepository ghRepo = mock(GHRepository.class);
     PagedIterable<GHCommitStatus> ghCommitStatuses = Mockito.mock(PagedIterable.class);
     List<GHCommitStatus> ghCommitStatusesList = new ArrayList<>();
@@ -129,8 +130,8 @@ public class PullRequestFacadeTest {
     when(pr.getHead().getSha()).thenReturn("abc123");
     when(ghRepo.listCommitStatuses(pr.getHead().getSha())).thenReturn(ghCommitStatuses);
     when(ghCommitStatuses.asList()).thenReturn(ghCommitStatusesList);
-    when(ghCommitStatusGHPRHContext.getContext()).thenReturn(PullRequestFacade.COMMIT_CONTEXT);
-    assertThat(facade.getCommitStatusForContext(pr, PullRequestFacade.COMMIT_CONTEXT).getContext()).isEqualTo(PullRequestFacade.COMMIT_CONTEXT);
+    when(ghCommitStatusGHPRHContext.getContext()).thenReturn(facade.getGithubCommitContext());
+    assertThat(facade.getCommitStatusForContext(pr, facade.getGithubCommitContext()).getContext()).isEqualTo(facade.getGithubCommitContext());
   }
 
   @Test


### PR DESCRIPTION
Adds support for multiple SonarQube servers analyzing one pull request