### PR TITLE
Support for multiple sonar projects in the same PR review

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,9 @@
   <inceptionYear>2015</inceptionYear>
   
   <properties>
-    <sonar.version>6.7</sonar.version>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <sonar.version>7.0</sonar.version>
     <sonar.pluginName>GitHub</sonar.pluginName>
     <sonar.pluginClass>org.sonar.plugins.github.GitHubPlugin</sonar.pluginClass>
 

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -137,6 +137,9 @@ public class GitHubPluginConfiguration {
     return !settings.getBoolean(GitHubPlugin.GITHUB_DISABLE_INLINE_COMMENTS);
   }
 
+  public String getProjectKey() {
+    return settings.getString(CoreProperties.PROJECT_KEY_PROPERTY);
+  }
   /**
    * Checks if a proxy was passed with command line parameters or configured in the system.
    * If only an HTTP proxy was configured then it's properties are copied to the HTTPS proxy (like SonarQube configuration)

--- a/src/main/java/org/sonar/plugins/github/GlobalReport.java
+++ b/src/main/java/org/sonar/plugins/github/GlobalReport.java
@@ -28,19 +28,21 @@ import org.sonar.api.batch.rule.Severity;
 
 public class GlobalReport {
   private final boolean tryReportIssuesInline;
+  private final String projectKeyMarkdown;
   private int[] newIssuesBySeverity = new int[Severity.values().length];
   private int extraIssueCount = 0;
   private int maxGlobalReportedIssues;
   private final ReportBuilder builder;
 
-  public GlobalReport(MarkDownUtils markDownUtils, boolean tryReportIssuesInline) {
-    this(markDownUtils, tryReportIssuesInline, GitHubPluginConfiguration.MAX_GLOBAL_ISSUES);
+  public GlobalReport(MarkDownUtils markDownUtils, String projectKeyMarkdown, boolean tryReportIssuesInline) {
+    this(markDownUtils, projectKeyMarkdown, tryReportIssuesInline, GitHubPluginConfiguration.MAX_GLOBAL_ISSUES);
   }
 
-  public GlobalReport(MarkDownUtils markDownUtils, boolean tryReportIssuesInline, int maxGlobalReportedIssues) {
+  public GlobalReport(MarkDownUtils markDownUtils, String projectKeyMarkdown, boolean tryReportIssuesInline, int maxGlobalReportedIssues) {
     this.tryReportIssuesInline = tryReportIssuesInline;
     this.maxGlobalReportedIssues = maxGlobalReportedIssues;
     this.builder = new MarkDownReportBuilder(markDownUtils);
+    this.projectKeyMarkdown = projectKeyMarkdown;
   }
 
   private void increment(Severity severity) {
@@ -50,12 +52,13 @@ public class GlobalReport {
   public String formatForMarkdown() {
     int newIssues = newIssues(Severity.BLOCKER) + newIssues(Severity.CRITICAL) + newIssues(Severity.MAJOR) + newIssues(Severity.MINOR) + newIssues(Severity.INFO);
     if (newIssues == 0) {
-      return "SonarQube analysis reported no issues.";
+        return projectKeyMarkdown + "\nSonarQube analysis reported no issues.";
     }
+    builder.append(projectKeyMarkdown);
 
     boolean hasInlineIssues = newIssues > extraIssueCount;
     boolean extraIssuesTruncated = extraIssueCount > maxGlobalReportedIssues;
-    builder.append("SonarQube analysis reported ").append(newIssues).append(" issue").append(newIssues > 1 ? "s" : "").append("\n");
+    builder.append("\nSonarQube analysis reported ").append(newIssues).append(" issue").append(newIssues > 1 ? "s" : "").append("\n");
     if (hasInlineIssues || extraIssuesTruncated) {
       appendSummaryBySeverity(builder);
     }

--- a/src/main/java/org/sonar/plugins/github/MarkDownUtils.java
+++ b/src/main/java/org/sonar/plugins/github/MarkDownUtils.java
@@ -38,6 +38,7 @@ public class MarkDownUtils {
 
   private static final String IMAGES_ROOT_URL = "https://sonarsource.github.io/sonar-github/";
   private final String ruleUrlPrefix;
+  private final String projectKey;
 
   public MarkDownUtils(Settings settings) {
     // If server base URL was not configured in SQ server then is is better to take URL configured on batch side
@@ -46,6 +47,7 @@ public class MarkDownUtils {
       baseUrl += "/";
     }
     this.ruleUrlPrefix = baseUrl;
+    this.projectKey = settings.getString(CoreProperties.PROJECT_KEY_PROPERTY);
   }
 
   public String inlineIssue(Severity severity, String message, String ruleKey) {
@@ -55,7 +57,9 @@ public class MarkDownUtils {
       .append(" ")
       .append(message)
       .append(" ")
-      .append(ruleLink);
+      .append(ruleLink)
+      .append("\n")
+      .append(getProjectNameMeta());
     return sb.toString();
   }
 
@@ -82,6 +86,10 @@ public class MarkDownUtils {
 
   String getRuleLink(String ruleKey) {
     return "[![rule](" + IMAGES_ROOT_URL + "rule.png)](" + ruleUrlPrefix + "coding_rules#rule_key=" + encodeForUrlParam(ruleKey) + ")";
+  }
+
+  String getProjectNameMeta(){
+    return "<sub>" + this.projectKey + "</sub>";
   }
 
   static String encodeForUrlParam(String url) {

--- a/src/main/java/org/sonar/plugins/github/PullRequestIssuePostJob.java
+++ b/src/main/java/org/sonar/plugins/github/PullRequestIssuePostJob.java
@@ -61,7 +61,7 @@ public class PullRequestIssuePostJob implements PostJob {
 
   @Override
   public void execute(PostJobContext context) {
-    GlobalReport report = new GlobalReport(markDownUtils, gitHubPluginConfiguration.tryReportIssuesInline());
+    GlobalReport report = new GlobalReport(markDownUtils, pullRequestFacade.getProjectKeyMarkdown(), gitHubPluginConfiguration.tryReportIssuesInline());
     try {
       Map<InputFile, Map<Integer, StringBuilder>> commentsToBeAddedByLine = processIssues(report, context.issues());
 
@@ -69,7 +69,9 @@ public class PullRequestIssuePostJob implements PostJob {
 
       pullRequestFacade.deleteOutdatedComments();
 
-      pullRequestFacade.createOrUpdateGlobalComments(report.hasNewIssue() ? report.formatForMarkdown() : null);
+      pullRequestFacade.createOrUpdateGlobalComments(report.hasNewIssue()
+              ? report.formatForMarkdown()
+              : null);
 
       pullRequestFacade.createOrUpdateSonarQubeStatus(report.getStatus(), report.getStatusDescription());
     } catch (Exception e) {


### PR DESCRIPTION
Added a new meta key in all comments posted by sonar with the actual sonar
projectKey. This is used to ensure only comments from the given projectKey 
are deleted/updated by sonar when changes occur.

This is done in order to allow multiple Sonar analysis of the same PR.
(e.g. for multi-module gradle projects for example where modules are
analysed individually by sonar)